### PR TITLE
feat: Implement API calls for settings management

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
@@ -56,6 +56,7 @@ public class TailLevelController {
     })
     @PostMapping(consumes = APPLICATION_JSON)
     public ResponseEntity<TailLevelResponse> createTailLevel(@RequestBody TailLevel request) {
+        log.info("Create Tail Level Request: {}", request.toString());
         return ResponseEntity.ok(tailLevelService.createTailLevel(request));
     }
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
@@ -56,7 +56,6 @@ public class TailLevelController {
     })
     @PostMapping(consumes = APPLICATION_JSON)
     public ResponseEntity<TailLevelResponse> createTailLevel(@RequestBody TailLevel request) {
-        log.info("Create Tail Level Request: {}", request.toString());
         return ResponseEntity.ok(tailLevelService.createTailLevel(request));
     }
 

--- a/n1netails-liquibase/Dockerfile
+++ b/n1netails-liquibase/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
-COPY target/n1netails-liquibase-0.1.5.jar app.jar
+COPY target/n1netails-liquibase-0.1.6.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/n1netails-liquibase/pom.xml
+++ b/n1netails-liquibase/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.n1netails</groupId>
 	<artifactId>n1netails-liquibase</artifactId>
-	<version>0.1.5</version>
+	<version>0.1.6</version>
 	<name>n1netails-liquibase</name>
 	<description>N1netails Liquibase Database Migration Tool</description>
 

--- a/n1netails-liquibase/src/main/resources/db/changelog/sql/db.changelog-00006-create-tail-sequences.sql
+++ b/n1netails-liquibase/src/main/resources/db/changelog/sql/db.changelog-00006-create-tail-sequences.sql
@@ -8,3 +8,6 @@ CREATE SEQUENCE IF NOT EXISTS tail_type_seq START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE IF NOT EXISTS tail_variable_seq START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE IF NOT EXISTS users_seq START WITH 1 INCREMENT BY 1;
 
+SELECT setval('ntail.tail_status_seq', (SELECT MAX(id) FROM ntail.tail_status), true);
+SELECT setval('ntail.tail_type_seq', (SELECT MAX(id) FROM ntail.tail_type), true);
+SELECT setval('ntail.tail_level_seq', (SELECT MAX(id) FROM ntail.tail_level), true);

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -117,54 +117,77 @@ export class SettingsComponent implements OnInit {
   addAlertLevel() {
     console.log('adding level', this.newTailLevel);
     const tailLevel: TailLevel = { name: this.newTailLevel, description: '' }
-    if (this.newTailLevel && !this.tailLevels.includes(tailLevel)) {
-      // todo call api
-      console.log('pushing new tail level', tailLevel);
-      this.tailLevels.push(tailLevel);
-      this.newTailLevel = '';
+    if (this.newTailLevel && !this.tailLevels.some(level => level.name === tailLevel.name)) {
+      this.tailLevelService.createTailLevel(tailLevel).subscribe(response => {
+        console.log('TailLevel created:', response);
+        this.tailLevels.push(response); // Assuming response is the created TailLevel
+        this.newTailLevel = '';
+      });
     }
   }
-  removeAlertLevel(level: string) {
-    // todo call api
-    this.tailLevels = this.tailLevels.filter(lvl => lvl.name !== level);
+  removeAlertLevel(levelName: string) {
+    const levelToRemove = this.tailLevels.find(lvl => lvl.name === levelName);
+    if (levelToRemove && levelToRemove.id) {
+      this.tailLevelService.deleteTailLevel(levelToRemove.id).subscribe(() => {
+        console.log('TailLevel deleted:', levelToRemove.id);
+        this.tailLevels = this.tailLevels.filter(lvl => lvl.id !== levelToRemove.id);
+      });
+    } else {
+      console.warn('TailLevel not found or id missing for level:', levelName);
+    }
   }
 
   addAlertStatus() {
     console.log('adding status', this.newTailStatus);
     const tailStatus: TailStatus = { name: this.newTailStatus }
-    if (this.newTailStatus && !this.tailStatuses.includes(tailStatus)) {
-      // todo call api
-      console.log('pushing new tail status', tailStatus);
-      this.tailStatuses.push(tailStatus);
-      this.newTailStatus = '';
+    if (this.newTailStatus && !this.tailStatuses.some(status => status.name === tailStatus.name)) {
+      this.tailStatusService.createTailStatus(tailStatus).subscribe(response => {
+        console.log('TailStatus created:', response);
+        this.tailStatuses.push(response); // Assuming response is the created TailStatus
+        this.newTailStatus = '';
+      });
     }
   }
 
-  removeAlertStatus(status: string) {
-    // todo call api
-    this.tailStatuses = this.tailStatuses.filter(stat => stat.name !== status);
+  removeAlertStatus(statusName: string) {
+    const statusToRemove = this.tailStatuses.find(stat => stat.name === statusName);
+    if (statusToRemove && statusToRemove.id) {
+      this.tailStatusService.deleteTailStatus(statusToRemove.id).subscribe(() => {
+        console.log('TailStatus deleted:', statusToRemove.id);
+        this.tailStatuses = this.tailStatuses.filter(stat => stat.id !== statusToRemove.id);
+      });
+    } else {
+      console.warn('TailStatus not found or id missing for status:', statusName);
+    }
   }
 
   addAlertType() {
     console.log('adding type', this.newTailType);
-    const tailType: TailType = { name: this.newTailType, description: '' }
-    if (this.newTailType && !this.tailTypes.includes(tailType)) {
-      // todo call api
-      console.log('pushing new tail status', tailType);
-      this.tailTypes.push(tailType);
-      this.newTailType = '';
+    const tailType: TailType = { name: this.newTailType, description: '' } // Assuming description is empty for new types or handled by backend
+    if (this.newTailType && !this.tailTypes.some(type => type.name === tailType.name)) {
+      this.tailTypeService.createTailType(tailType).subscribe(response => {
+        console.log('TailType created:', response);
+        this.tailTypes.push(response); // Assuming response is the created TailType
+        this.newTailType = '';
+      });
     }
   }
 
-  removeAlertType(type: string) {
-    // todo call api
-    this.tailTypes = this.tailTypes.filter(tail => tail.name !== type);
-
-    // todo implement this later
-    // this.updateAlertTypeOptions();
-    // this.preferredAlertTypes = this.preferredAlertTypes.filter(
-    //   (t: string) => t !== type
-    // );
+  removeAlertType(typeName: string) {
+    const typeToRemove = this.tailTypes.find(type => type.name === typeName);
+    if (typeToRemove && typeToRemove.id) {
+      this.tailTypeService.deleteTailType(typeToRemove.id).subscribe(() => {
+        console.log('TailType deleted:', typeToRemove.id);
+        this.tailTypes = this.tailTypes.filter(type => type.id !== typeToRemove.id);
+        // todo implement this later
+        // this.updateAlertTypeOptions();
+        // this.preferredAlertTypes = this.preferredAlertTypes.filter(
+        //   (t: string) => t !== typeName
+        // );
+      });
+    } else {
+      console.warn('TailType not found or id missing for type:', typeName);
+    }
   }
 
   // Preferred Alert Types

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -9,9 +9,9 @@ import { NzTableModule } from 'ng-zorro-antd/table';
 import { NzCheckboxModule, NzCheckBoxOptionInterface } from 'ng-zorro-antd/checkbox';
 import { CommonModule } from '@angular/common';
 import { UserService } from '../../service/user.service';
-import { TailLevel, TailLevelService } from '../../service/tail-level.service';
-import { TailStatus, TailStatusService } from '../../service/tail-status.service';
-import { TailType, TailTypeService } from '../../service/tail-type.service';
+import { TailLevel, TailLevelResponse, TailLevelService } from '../../service/tail-level.service';
+import { TailStatus, TailStatusResponse, TailStatusService } from '../../service/tail-status.service';
+import { TailType, TailTypeResponse, TailTypeService } from '../../service/tail-type.service';
 import { User } from '../../model/user';
 import { AuthenticationService } from '../../service/authentication.service';
 
@@ -47,9 +47,9 @@ export class SettingsComponent implements OnInit {
   private user: User;
 
   // Alert Levels, Statuses, Types
-  tailLevels: TailLevel[] = [];
-  tailStatuses: TailStatus[] = [];
-  tailTypes: TailType[] = [];
+  tailLevels: TailLevelResponse[] = [];
+  tailStatuses: TailStatusResponse[] = [];
+  tailTypes: TailTypeResponse[] = [];
 
   newTailLevel: string = '';
   newTailStatus: string = '';
@@ -67,15 +67,15 @@ export class SettingsComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.tailLevelService.getTailLevels().subscribe((response: TailLevel[]) => {
+    this.tailLevelService.getTailLevels().subscribe((response: TailLevelResponse[]) => {
       this.tailLevels = response;
       console.log('tail levels:', this.tailLevels);
     });
-    this.tailStatusService.getTailStatusList().subscribe((response: TailStatus[]) => {
+    this.tailStatusService.getTailStatusList().subscribe((response: TailStatusResponse[]) => {
       this.tailStatuses = response;
       console.log('tail statuses:', this.tailStatuses);
     });
-    this.tailTypeService.getTailTypes().subscribe((response: TailType[]) => {
+    this.tailTypeService.getTailTypes().subscribe((response: TailTypeResponse[]) => {
       this.tailTypes = response;
       console.log('tail types:', this.tailTypes);
     });


### PR DESCRIPTION
I've implemented API calls for creating and deleting Tail Levels, Tail Statuses, and Tail Types within the settings component.

- I replaced placeholder comments with actual service calls to `TailLevelService`, `TailStatusService`, and `TailTypeService`.
- I added logic to handle responses from API calls, including logging and updating local component arrays (`tailLevels`, `tailStatuses`, `tailTypes`).
- I ensured that `add` methods check for duplicates by name before making an API call.
- I modified `remove` methods to find items by name to retrieve their ID, then use the ID for the delete API call. Local arrays are updated upon successful deletion.
- Error handling for `remove` methods includes logging a warning if an item isn't found by name or lacks an ID.