### PR TITLE
feat: Add endpoint for MTTR last 7 days

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailMetricsController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailMetricsController.java
@@ -3,6 +3,7 @@ package com.n1netails.n1netails.api.controller;
 import com.n1netails.n1netails.api.model.request.TimezoneRequest;
 import com.n1netails.n1netails.api.model.response.TailAlertsPerHourResponse;
 import com.n1netails.n1netails.api.model.response.TailMonthlySummaryResponse;
+import com.n1netails.n1netails.api.model.response.TailDatasetResponse; // Added import
 import com.n1netails.n1netails.api.model.response.TailResponse;
 import com.n1netails.n1netails.api.service.TailMetricsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -113,5 +114,14 @@ public class TailMetricsController {
     @PostMapping("/monthly-summary")
     public TailMonthlySummaryResponse getTailMonthlySummary(@RequestBody TimezoneRequest timezoneRequest) {
         return tailMetricsService.getTailMonthlySummary(timezoneRequest.getTimezone());
+    }
+
+    @Operation(summary = "Get MTTR for the last 7 days.", responses = {
+            @ApiResponse(responseCode = "200", description = "MTTR data for the last 7 days",
+                    content = @Content(schema = @Schema(implementation = TailDatasetResponse.class)))
+    })
+    @GetMapping("/mttr/last-7-days")
+    public TailDatasetResponse getTailMTTRLast7Days() {
+        return tailMetricsService.getTailMTTRLast7Days();
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/TailDatasetResponse.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/TailDatasetResponse.java
@@ -12,5 +12,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class TailDatasetResponse {
     private String label;
-    private List<Integer> data;
+    private List<Double> data;
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailMetricsService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailMetricsService.java
@@ -22,4 +22,6 @@ public interface TailMetricsService {
     TailAlertsPerHourResponse getTailAlertsPerHour(String timezone);
 
     TailMonthlySummaryResponse getTailMonthlySummary(String timezone);
+
+    TailDatasetResponse getTailMTTRLast7Days();
 }


### PR DESCRIPTION
Adds a new endpoint `/api/metrics/tails/mttr/last-7-days` to provide Mean Time To Resolve (MTTR) data for TailEntity objects over the past 7 days.

The endpoint returns data in the following format: {
  "labels": ["MMM dd", ...],
  "data": [mttr_for_day_1_in_hours, ...]
}

Changes include:
- Modified `TailDatasetResponse` to use `List<Double>` for data.
- Added `getTailMTTRLast7Days()` to `TailMetricsService` interface.
- Implemented `getTailMTTRLast7Days()` in `TailMetricsServiceImpl`, including logic to calculate daily MTTR in hours.
- Added the new GET endpoint in `TailMetricsController`.
- Unit tests were skipped as you requested.