### PR TITLE
feat: Implement password reset functionality

### DIFF
--- a/n1netails-api/Dockerfile
+++ b/n1netails-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
-COPY target/n1netails-api-0.1.18.jar app.jar
+COPY target/n1netails-api-0.1.19.jar app.jar
 EXPOSE 9901
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/n1netails-api/pom.xml
+++ b/n1netails-api/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.n1netails</groupId>
 	<artifactId>n1netails-api</artifactId>
-	<version>0.1.18</version>
+	<version>0.1.19</version>
 	<name>n1netails-api</name>
 	<description>N1netails Alert Service API</description>
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/constant/ProjectSecurityConstant.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/constant/ProjectSecurityConstant.java
@@ -19,8 +19,6 @@ public class ProjectSecurityConstant {
             "/api/user/login",
             "/api/user/register",
             "/api/alert/**",
-//            "/api/metrics/tails/**",
-//            "/api/tail/**",
             "/"
     };
 
@@ -29,5 +27,8 @@ public class ProjectSecurityConstant {
     public static final String FORBIDDEN_MESSAGE = "You need to login in order to access this page.";
     public static final String ACCESS_DENIED_MESSAGE = "You do not have permission to access this page.";
 
+    // Regex: at least 8 chars, 1 uppercase, 1 special char
+    public static final String PASSWORD_REGEX = "^(?=.*[A-Z])(?=.*[!@#$%^&*()_+\\-={}\\[\\]:;'\"\\\\|,.<>/?]).{8,}$";
+    public static final String PASSWORD_REGEX_EXCEPTION_MESSAGE = "The password needs to contain at least 8 characters, 1 uppercase character, and 1 special character.";
     private ProjectSecurityConstant() {}
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasswordController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasswordController.java
@@ -1,10 +1,16 @@
 package com.n1netails.n1netails.api.controller;
 
+import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.service.UserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,8 +23,26 @@ import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATIO
 @RequestMapping(path = {"/api/password"}, produces = APPLICATION_JSON)
 public class PasswordController {
 
+    private final UserService userService;
+
     @GetMapping("/hello")
     public ResponseEntity<String> hello() {
         return ResponseEntity.ok("hello");
+    }
+
+    @PostMapping("/reset")
+    public ResponseEntity<String> resetPassword(@RequestBody PasswordResetRequest request) {
+        try {
+            userService.updatePassword(request.getEmail(), request.getNewPassword());
+            return ResponseEntity.ok("Password updated successfully");
+        } catch (UserNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @Data
+    private static class PasswordResetRequest {
+        private String email;
+        private String newPassword;
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/ExceptionController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/ExceptionController.java
@@ -1,6 +1,7 @@
 package com.n1netails.n1netails.api.exception;
 
 import com.n1netails.n1netails.api.exception.type.EmailExistException;
+import com.n1netails.n1netails.api.exception.type.PasswordRegexException;
 import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
 import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
 import com.n1netails.n1netails.api.model.response.HttpErrorResponse;
@@ -11,22 +12,39 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.nio.file.AccessDeniedException;
+
 import static org.springframework.http.HttpStatus.*;
 
 @Slf4j
 @RestControllerAdvice
 public class ExceptionController implements ErrorController {
 
-//    /**
-//     * Bad Request Exception (400)
-//     * @param exception bad request exception
-//     * @return http error response
-//     */
-//    @ExceptionHandler()
-//    public ResponseEntity<HttpErrorResponse> badRequestException(Exception exception) {
-//        log.error(exception.getMessage());
-//        return createHttpResponse(BAD_REQUEST, exception.getMessage());
-//    }
+    /**
+     * Bad Request Exception (400)
+     * @param exception bad request exception
+     * @return http error response
+     */
+    @ExceptionHandler({
+            PasswordRegexException.class
+    })
+    public ResponseEntity<HttpErrorResponse> badRequestException(Exception exception) {
+        log.error(exception.getMessage());
+        return createHttpResponse(BAD_REQUEST, exception.getMessage());
+    }
+
+    /**
+     * Unauthorized Exception (401)
+     * @param exception unauthorized exception
+     * @return http error response
+     */
+    @ExceptionHandler({
+            AccessDeniedException.class
+    })
+    public ResponseEntity<HttpErrorResponse> unauthorizedException(Exception exception) {
+        log.error(exception.getMessage());
+        return createHttpResponse(UNAUTHORIZED, exception.getMessage());
+    }
 
     /**
      * Not Found Exception (404)

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/type/PasswordRegexException.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/type/PasswordRegexException.java
@@ -1,0 +1,7 @@
+package com.n1netails.n1netails.api.exception.type;
+
+public class PasswordRegexException extends Exception {
+    public PasswordRegexException(String message) {
+        super(message);
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/PasswordResetRequest.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/PasswordResetRequest.java
@@ -1,0 +1,9 @@
+package com.n1netails.n1netails.api.model.request;
+
+import lombok.Data;
+
+@Data
+public class PasswordResetRequest {
+    private String email;
+    private String newPassword;
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/UserService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/UserService.java
@@ -10,4 +10,5 @@ public interface UserService {
     UsersEntity findUserByEmail(String email);
     UsersEntity register(UserRegisterRequest user) throws UserNotFoundException, EmailExistException;
     UsersEntity editUser(UsersEntity user);
+    UsersEntity updatePassword(String email, String newPassword) throws UserNotFoundException;
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/UserServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/UserServiceImpl.java
@@ -142,4 +142,13 @@ public class UserServiceImpl implements UserService, UserDetailsService {
             return null;
         }
     }
+
+    @Override
+    public UsersEntity updatePassword(String email, String newPassword) throws UserNotFoundException {
+        UsersEntity user = userRepository.findUserByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("User not found with email: " + email));
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+        return user;
+    }
 }

--- a/n1netails-ui/Dockerfile
+++ b/n1netails-ui/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
-COPY target/n1netails-ui-0.1.18.jar app.jar
+COPY target/n1netails-ui-0.1.19.jar app.jar
 EXPOSE 9900
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/n1netails-ui/pom.xml
+++ b/n1netails-ui/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.n1netails</groupId>
 	<artifactId>n1netails-ui</artifactId>
-	<version>0.1.18</version>
+	<version>0.1.19</version>
 	<name>n1netails-ui</name>
 	<description>N1netails Alert Service UI</description>
 

--- a/n1netails-ui/src/main/typescript/package.json
+++ b/n1netails-ui/src/main/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
@@ -167,18 +167,30 @@
           </nz-card>
 
           <nz-card nzTitle="Password Reset" class="tails-primary-color" [nzBordered]="false">
-            <form nz-form (ngSubmit)="onPasswordReset()" #passwordForm="ngForm" class="password-form">
-              <nz-form-item>
-                <nz-form-label [nzSpan]="10" nzFor="newPassword" nzRequired>New Password: </nz-form-label>
-                <nz-form-control [nzSpan]="10">
-                  <input nz-input type="password" id="newPassword" name="newPassword" [(ngModel)]="newPassword" required
-                    placeholder="Enter new password" />
-                </nz-form-control>
-              </nz-form-item>
-            </form>
-            <button nz-button nzType="primary" type="submit" [disabled]="!passwordForm.valid">Reset Password</button>
+            <div *ngIf="passwordResetErrorMessage" style="color: #ff4d4f; margin-bottom: 12px; font-weight: 500;">
+              {{ passwordResetErrorMessage }}
+            </div>
+            <div style="width: 100%;">
+              <form nz-form (ngSubmit)="onPasswordReset()" #passwordForm="ngForm" class="password-form">
+                <nz-form-item style="margin-bottom: 0;">
+                  <nz-form-label [nzSpan]="10" nzFor="newPassword" nzRequired>New Password: </nz-form-label>
+                  <nz-form-control [nzSpan]="10">
+                    <input nz-input type="password" id="newPassword" name="newPassword" [(ngModel)]="newPassword" required
+                      placeholder="Enter new password" />
+                  </nz-form-control>
+                  <button
+                    nz-button
+                    nzType="primary"
+                    type="submit"
+                    [disabled]="!passwordForm.valid"
+                    style="min-width: 140px; margin-left: 126px; display: block;"
+                  >
+                    Reset Password
+                  </button>
+                </nz-form-item>
+              </form>
+            </div>
           </nz-card>
-
         </div>
       </div>
     </nz-content>

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
@@ -17,6 +17,7 @@ nz-header {
 .token-form,
 .password-form {
   display: flex;
+  flex-direction: row;
   align-items: flex-end;
   gap: 16px;
   margin-bottom: 24px;

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -15,6 +15,7 @@ import { User } from '../../model/user';
 import { AuthenticationService } from '../../service/authentication.service';
 import { N1neTokenService, N1neTokenResponse, CreateTokenRequest } from '../../service/n1ne-token.service';
 import { NzDividerModule } from 'ng-zorro-antd/divider';
+import { NzMessageService } from 'ng-zorro-antd/message';
 
 @Component({
   selector: 'app-settings',
@@ -47,6 +48,7 @@ export class SettingsComponent implements OnInit {
   newTailType: string = '';
 
   constructor(
+    private msg: NzMessageService,
     private authenticationService: AuthenticationService,
     private tailLevelService: TailLevelService,
     private tailStatusService: TailStatusService,
@@ -193,6 +195,7 @@ export class SettingsComponent implements OnInit {
 
   // Password Reset
   onPasswordReset() {
+    console.log('REQUEST TO RESET PASSWORD');
     this.passwordResetSuccessMessage = '';
     this.passwordResetErrorMessage = '';
 
@@ -206,16 +209,21 @@ export class SettingsComponent implements OnInit {
       return;
     }
 
+    console.log('new password:', this.newPassword);
+    console.log('user email', this.user.email);
+
     this.authenticationService.resetPassword(this.user.email, this.newPassword).subscribe({
       next: () => {
         this.passwordResetSuccessMessage = 'Password updated successfully.';
         console.log('Password updated successfully.');
         this.newPassword = '';
+        this.msg.success('Password updated successfully.');
       },
       error: (error) => {
-        this.passwordResetErrorMessage = 'Failed to update password. ' + (error.error?.message || error.message || '');
+        this.passwordResetErrorMessage = 'Failed to update password. The password needs to contain at least 8 characters, 1 uppercase character, and 1 special character.';
         console.error('Failed to update password:', error);
         this.newPassword = '';
+        this.msg.error(this.passwordResetErrorMessage);
       }
     });
   }

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -32,6 +32,11 @@ export class SettingsComponent implements OnInit {
   isLoading: boolean = false;
   errorMessage: string = '';
 
+  // Password Reset
+  newPassword: string = '';
+  passwordResetSuccessMessage: string = '';
+  passwordResetErrorMessage: string = '';
+
   // Alert Levels, Statuses, Types
   tailLevels: TailLevelResponse[] = [];
   tailStatuses: TailStatusResponse[] = [];
@@ -187,11 +192,32 @@ export class SettingsComponent implements OnInit {
   }
 
   // Password Reset
-  newPassword: string = '';
   onPasswordReset() {
-    // Implement password reset logic here
-    this.newPassword = '';
-    // Show notification if needed
+    this.passwordResetSuccessMessage = '';
+    this.passwordResetErrorMessage = '';
+
+    if (!this.newPassword) {
+      this.passwordResetErrorMessage = 'New password cannot be empty.';
+      return;
+    }
+
+    if (!this.user || !this.user.email) {
+      this.passwordResetErrorMessage = 'User email is not available.';
+      return;
+    }
+
+    this.authenticationService.resetPassword(this.user.email, this.newPassword).subscribe({
+      next: () => {
+        this.passwordResetSuccessMessage = 'Password updated successfully.';
+        console.log('Password updated successfully.');
+        this.newPassword = '';
+      },
+      error: (error) => {
+        this.passwordResetErrorMessage = 'Failed to update password. ' + (error.error?.message || error.message || '');
+        console.error('Failed to update password:', error);
+        this.newPassword = '';
+      }
+    });
   }
 
   addAlertLevel() {

--- a/n1netails-ui/src/main/typescript/src/app/service/authentication.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/authentication.service.ts
@@ -81,4 +81,8 @@ export class AuthenticationService {
     this.logOut();
     return false;
   }
+
+  public resetPassword(email: string, newPassword: string): Observable<any> {
+    return this.http.post<any>(`${this.host}/api/password/reset`, { email, newPassword });
+  }
 }

--- a/n1netails-ui/src/main/typescript/src/app/service/authentication.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/authentication.service.ts
@@ -82,7 +82,7 @@ export class AuthenticationService {
     return false;
   }
 
-  public resetPassword(email: string, newPassword: string): Observable<any> {
-    return this.http.post<any>(`${this.host}/api/password/reset`, { email, newPassword });
+  public resetPassword(email: string, newPassword: string): Observable<string> {
+    return this.http.post(`${this.host}/api/password/reset`, { email, newPassword }, { responseType: 'text' });
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.n1netails</groupId>
     <artifactId>n1netails</artifactId>
-    <version>0.1.23</version>
+    <version>0.1.24</version>
     <packaging>pom</packaging>
 
     <url/>


### PR DESCRIPTION
Adds a password reset feature allowing you to change your password from the settings page.

Backend:
- Updated `UserService` and `UserServiceImpl` to include an `updatePassword` method that hashes the new password and updates your record.
- Updated `PasswordController` with a new POST endpoint `/api/password/reset` that takes your email and new password, and calls the `UserService` to perform the update.

Frontend:
- Added a `resetPassword` method to `AuthenticationService` to call the new backend endpoint.
- Updated `SettingsComponent`'s `onPasswordReset` method to:
    - Use the `AuthenticationService.resetPassword` method.
    - Display success or error messages to you.
    - Clear the password field after the attempt.