### PR TITLE
feat: Implement authorization checks and refactor controllers

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/N1neTokenController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/N1neTokenController.java
@@ -4,12 +4,16 @@ import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
 import com.n1netails.n1netails.api.model.request.CreateTokenRequest;
 import com.n1netails.n1netails.api.model.response.N1neTokenResponse;
 import com.n1netails.n1netails.api.service.AuthorizationService;
+import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
 import com.n1netails.n1netails.api.service.N1neTokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
+import org.springframework.security.access.AccessDeniedException;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+// import java.nio.file.AccessDeniedException; // Replaced
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +21,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.nio.file.AccessDeniedException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -52,17 +58,38 @@ public class N1neTokenController {
         }
     }
 
-    // TODO CONSIDER IF THIS IS NEEDED SO ORGANIZATION ADMINS CAN VIEW ALL TOKENS
-//    @Operation(summary = "Get all tokens", responses = {
-//            @ApiResponse(responseCode = "200", description = "List of tokens",
-//                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = N1neTokenResponse.class))))
-//    })
-//    @GetMapping
-//    @PreAuthorize("hasAnyAuthority('user:admin')")
-//    public ResponseEntity<List<N1neTokenResponse>> getAll() {
-//        List<N1neTokenResponse> n1neTokenResponseList = n1neTokenService.getAll();
-//        return ResponseEntity.ok(n1neTokenResponseList);
-//    }
+    @Operation(summary = "Get all tokens (Super Admin or Org Admin)", responses = {
+            @ApiResponse(responseCode = "200", description = "List of tokens",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = N1neTokenResponse.class))))
+    })
+    @GetMapping
+    public ResponseEntity<List<N1neTokenResponse>> getAll(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        List<N1neTokenResponse> responseList;
+
+        if (authorizationService.isSuperAdmin(currentUser)) {
+            log.info("Super Admin {} fetching all N1ne tokens.", currentUser.getUsername());
+            responseList = n1neTokenService.getAllTokens();
+        } else {
+            Set<Long> adminOrgIds = currentUser.getOrganizations().stream()
+                    .filter(org -> {
+                        // We need to call isOrganizationAdmin with the principal and org ID.
+                        // The principal passed to isOrganizationAdmin should be the currentUser.
+                        return authorizationService.isOrganizationAdmin(currentUser, org.getId());
+                    })
+                    .map(OrganizationEntity::getId)
+                    .collect(Collectors.toSet());
+
+            if (!adminOrgIds.isEmpty()) {
+                log.info("Org Admin {} fetching N1ne tokens for organizations: {}", currentUser.getUsername(), adminOrgIds);
+                responseList = n1neTokenService.getAllTokensForOrganizations(adminOrgIds);
+            } else {
+                log.info("User {} is not a Super Admin and not an admin of any organization. Returning empty list of tokens.", currentUser.getUsername());
+                responseList = Collections.emptyList();
+            }
+        }
+        return ResponseEntity.ok(responseList);
+    }
 
     @Operation(summary = "Get all tokens by user id", responses = {
             @ApiResponse(responseCode = "200", description = "List of tokens by user id",
@@ -73,12 +100,17 @@ public class N1neTokenController {
             @RequestHeader(AUTHORIZATION) String authorizationHeader,
             @PathVariable Long userId
     ) throws UserNotFoundException, AccessDeniedException {
-        if (authorizationService.isSelf(authorizationHeader, userId)) {
-            log.info("Get all tokens by user id");
+        // For fetching tokens by user ID, ensuring the caller is the user themselves OR a super admin.
+        // Org admin check could be added if org admins should see tokens of users in their org.
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        if (currentUser.getId().equals(userId) || authorizationService.isSuperAdmin(currentUser)) {
+            log.info("User {} fetching tokens for user ID: {}. Caller isSelf: {}, isSuperAdmin: {}",
+                    currentUser.getUsername(), userId, currentUser.getId().equals(userId), authorizationService.isSuperAdmin(currentUser));
             List<N1neTokenResponse> n1neTokenResponseList = n1neTokenService.getAllByUserId(userId);
             return ResponseEntity.ok(n1neTokenResponseList);
         } else {
-            throw new AccessDeniedException("Get User Tokens request access denied.");
+            log.warn("User {} attempted to fetch tokens for user ID {} without sufficient privileges.", currentUser.getUsername(), userId);
+            throw new AccessDeniedException("You do not have permission to view these tokens.");
         }
     }
 
@@ -91,12 +123,22 @@ public class N1neTokenController {
             @RequestHeader(AUTHORIZATION) String authorizationHeader,
             @PathVariable Long id
     ) throws UserNotFoundException, AccessDeniedException {
-        N1neTokenResponse n1neToken = this.n1neTokenService.getById(id);
-        if (authorizationService.isOwnerOrOrganizationAdmin(authorizationHeader, n1neToken.getUserId(), n1neToken.getOrganizationId())) {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        N1neTokenResponse n1neToken = this.n1neTokenService.getById(id); // Fetches the token details
+
+        // Check if the current user is the owner of the token, or an admin of the token's organization, or a super admin
+        boolean isOwner = currentUser.getId().equals(n1neToken.getUserId());
+        boolean isOrgAdmin = authorizationService.isOrganizationAdmin(currentUser, n1neToken.getOrganizationId());
+        boolean isSuperAdmin = authorizationService.isSuperAdmin(currentUser);
+
+        if (isOwner || isOrgAdmin || isSuperAdmin) {
+            log.info("User {} revoking token ID: {}. IsOwner: {}, IsOrgAdmin: {}, IsSuperAdmin: {}",
+                    currentUser.getUsername(), id, isOwner, isOrgAdmin, isSuperAdmin);
             n1neTokenService.revoke(id);
             return ResponseEntity.noContent().build();
         } else {
-            throw new AccessDeniedException("Revoke token request access denied.");
+            log.warn("User {} attempted to revoke token ID {} without sufficient privileges.", currentUser.getUsername(), id);
+            throw new AccessDeniedException("You do not have permission to revoke this token.");
         }
     }
 
@@ -109,12 +151,21 @@ public class N1neTokenController {
             @RequestHeader(AUTHORIZATION) String authorizationHeader,
             @PathVariable Long id
     ) throws AccessDeniedException, UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         N1neTokenResponse n1neToken = this.n1neTokenService.getById(id);
-        if (authorizationService.isOwnerOrOrganizationAdmin(authorizationHeader, n1neToken.getUserId(), n1neToken.getOrganizationId())) {
+
+        boolean isOwner = currentUser.getId().equals(n1neToken.getUserId());
+        boolean isOrgAdmin = authorizationService.isOrganizationAdmin(currentUser, n1neToken.getOrganizationId());
+        boolean isSuperAdmin = authorizationService.isSuperAdmin(currentUser);
+
+        if (isOwner || isOrgAdmin || isSuperAdmin) {
+            log.info("User {} enabling token ID: {}. IsOwner: {}, IsOrgAdmin: {}, IsSuperAdmin: {}",
+                    currentUser.getUsername(), id, isOwner, isOrgAdmin, isSuperAdmin);
             n1neTokenService.enable(id);
             return ResponseEntity.noContent().build();
         } else {
-            throw new AccessDeniedException("Enable token request access denied.");
+            log.warn("User {} attempted to enable token ID {} without sufficient privileges.", currentUser.getUsername(), id);
+            throw new AccessDeniedException("You do not have permission to enable this token.");
         }
     }
 
@@ -127,12 +178,21 @@ public class N1neTokenController {
             @RequestHeader(AUTHORIZATION) String authorizationHeader,
             @PathVariable Long id
     ) throws UserNotFoundException, AccessDeniedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         N1neTokenResponse n1neToken = this.n1neTokenService.getById(id);
-        if (authorizationService.isSelf(authorizationHeader, n1neToken.getUserId())) {
+
+        // Typically, only owners or super admins can delete. Org admins might only revoke/disable.
+        boolean isOwner = currentUser.getId().equals(n1neToken.getUserId());
+        boolean isSuperAdmin = authorizationService.isSuperAdmin(currentUser);
+
+        if (isOwner || isSuperAdmin) {
+            log.info("User {} deleting token ID: {}. IsOwner: {}, IsSuperAdmin: {}",
+                    currentUser.getUsername(), id, isOwner, isSuperAdmin);
             n1neTokenService.delete(id);
             return ResponseEntity.noContent().build();
         } else {
-            throw new AccessDeniedException("Delete token request access denied.");
+            log.warn("User {} attempted to delete token ID {} without sufficient privileges.", currentUser.getUsername(), id);
+            throw new AccessDeniedException("You do not have permission to delete this token.");
         }
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/OrganizationController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/OrganizationController.java
@@ -1,23 +1,28 @@
 package com.n1netails.n1netails.api.controller;
 
+import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
 import com.n1netails.n1netails.api.model.request.OrganizationRequest;
+import com.n1netails.n1netails.api.service.AuthorizationService;
 import com.n1netails.n1netails.api.service.OrganizationService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.access.AccessDeniedException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
+// import org.springframework.security.core.annotation.AuthenticationPrincipal; // No longer needed
+// import org.springframework.security.core.userdetails.UserDetails; // No longer needed
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,9 +33,10 @@ import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATIO
 public class OrganizationController {
 
     private final OrganizationService organizationService;
+    private final AuthorizationService authorizationService;
 
     @PostMapping
-    @PreAuthorize("hasAuthority('user:super')") // Corresponds to SUPER_ADMIN_AUTHORITIES which includes 'user:super'
+    @PreAuthorize("hasAuthority('user:super')")
     public ResponseEntity<OrganizationEntity> createOrganization(@Valid @RequestBody OrganizationRequest organizationRequest) {
         OrganizationEntity newOrganization = organizationService.createOrganization(organizationRequest);
         return new ResponseEntity<>(newOrganization, HttpStatus.CREATED);
@@ -58,26 +64,34 @@ public class OrganizationController {
         return ResponseEntity.ok().build();
     }
 
-    // TODO POSSIBLY REFACTOR THE @AuthenticationPrincipal TO INSTEAD USE THE AuthorizationServiceImpl
     // Endpoints for Admin (of an org) to manage their own organization's members
     @PostMapping("/{organizationId}/members/{targetUserId}")
-    @PreAuthorize("hasAuthority('user:admin')") // 'user:create' is in ADMIN_AUTHORITIES and SUPER_ADMIN_AUTHORITIES
-    public ResponseEntity<Void> addMemberToOrganization(@PathVariable Long organizationId, @PathVariable Long targetUserId, @AuthenticationPrincipal UserDetails adminPrincipal) {
-        if (adminPrincipal == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    @PreAuthorize("hasAuthority('user:admin')")
+    public ResponseEntity<Void> addMemberToOrganization(@RequestHeader(AUTHORIZATION) String authorizationHeader,
+                                                        @PathVariable Long organizationId,
+                                                        @PathVariable Long targetUserId) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        if (!authorizationService.isOrganizationAdmin(currentUser, organizationId)) {
+            log.warn("User {} attempted to add member to organization {} without being an admin.", currentUser.getUsername(), organizationId);
+            throw new AccessDeniedException("User is not an admin of this organization.");
         }
-        organizationService.addMemberToMyOrganization(organizationId, targetUserId, adminPrincipal.getUsername());
+        log.info("Admin {} adding member {} to organization {}", currentUser.getUsername(), targetUserId, organizationId);
+        organizationService.addMemberToMyOrganization(organizationId, targetUserId, currentUser.getUsername());
         return ResponseEntity.ok().build();
     }
 
-    // TODO POSSIBLY REFACTOR THE @AuthenticationPrincipal TO INSTEAD USE THE AuthorizationServiceImpl
     @DeleteMapping("/{organizationId}/members/{targetUserId}")
     @PreAuthorize("hasAuthority('user:admin')")
-    public ResponseEntity<Void> removeMemberFromOrganization(@PathVariable Long organizationId, @PathVariable Long targetUserId, @AuthenticationPrincipal UserDetails adminPrincipal) {
-        if (adminPrincipal == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    public ResponseEntity<Void> removeMemberFromOrganization(@RequestHeader(AUTHORIZATION) String authorizationHeader,
+                                                             @PathVariable Long organizationId,
+                                                             @PathVariable Long targetUserId) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        if (!authorizationService.isOrganizationAdmin(currentUser, organizationId)) {
+            log.warn("User {} attempted to remove member from organization {} without being an admin.", currentUser.getUsername(), organizationId);
+            throw new AccessDeniedException("User is not an admin of this organization.");
         }
-        organizationService.removeMemberFromMyOrganization(organizationId, targetUserId, adminPrincipal.getUsername());
+        log.info("Admin {} removing member {} from organization {}", currentUser.getUsername(), targetUserId, organizationId);
+        organizationService.removeMemberFromMyOrganization(organizationId, targetUserId, currentUser.getUsername());
         return ResponseEntity.ok().build();
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailController.java
@@ -1,22 +1,23 @@
 package com.n1netails.n1netails.api.controller;
 
-import com.n1netails.n1netails.api.exception.type.TailLevelNotFoundException;
-import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
-import com.n1netails.n1netails.api.exception.type.TailStatusNotFoundException;
-import com.n1netails.n1netails.api.exception.type.TailTypeNotFoundException;
+import com.n1netails.n1netails.api.exception.type.*;
+import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.request.ResolveTailRequest;
 import com.n1netails.n1netails.api.model.request.TailPageRequest;
-import com.n1netails.n1netails.api.model.request.TailRequest;
+// import com.n1netails.n1netails.api.model.request.TailRequest; // No longer used in this controller directly
 import com.n1netails.n1netails.api.model.response.HttpErrorResponse;
 import com.n1netails.n1netails.api.model.response.TailResponse;
+import com.n1netails.n1netails.api.service.AuthorizationService;
 import com.n1netails.n1netails.api.service.TailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.security.access.AccessDeniedException;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -35,28 +36,46 @@ import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATIO
 public class TailController {
 
     private final TailService tailService;
+    private final AuthorizationService authorizationService;
 
     @Operation(summary = "Get tail by ID", responses = {
             @ApiResponse(responseCode = "200", description = "Tail found",
                     content = @Content(schema = @Schema(implementation = TailResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Tail not found",
                     content = @Content(schema = @Schema(implementation = HttpErrorResponse.class)))
     })
     @GetMapping("/{id}")
-    public ResponseEntity<TailResponse> getById(@PathVariable Long id) {
-        // TODO UPDATE THIS SO ONLY THE USER AND USERS IN THE SAME THE ORGANIZATION CAN GET THE TAIL
-        return ResponseEntity.ok(tailService.getTailById(id));
+    public ResponseEntity<TailResponse> getById(@PathVariable Long id,
+                                                @RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException, AccessDeniedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        TailResponse tail = tailService.getTailById(id);
+
+        boolean canAccess = authorizationService.isTailOwner(currentUser, tail.getUserId()) ||
+                            authorizationService.belongsToOrganization(currentUser, tail.getOrganizationId());
+
+        if (!canAccess) {
+            log.warn("User {} (ID: {}) attempted to access tail {} which they do not own or belong to its organization {}.",
+                    currentUser.getUsername(), currentUser.getId(), id, tail.getOrganizationId());
+            throw new AccessDeniedException("User cannot access this tail.");
+        }
+        log.info("User {} (ID: {}) accessed tail {}", currentUser.getUsername(), currentUser.getId(), id);
+        return ResponseEntity.ok(tail);
     }
 
     @Operation(summary = "Get tails by page", responses = {
             @ApiResponse(responseCode = "200", description = "Page of tails",
-                    content = @Content(schema = @Schema(implementation = Page.class))) // Note: Ideally, you'd use a Page<TailResponse> schema
+                    content = @Content(schema = @Schema(implementation = Page.class)))
     })
     @PostMapping("/page")
-    public ResponseEntity<Page<TailResponse>> getTailsByPage(@RequestBody TailPageRequest request) throws TailTypeNotFoundException, TailLevelNotFoundException, TailStatusNotFoundException {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-        return ResponseEntity.ok(tailService.getTails(request));
+    public ResponseEntity<Page<TailResponse>> getTailsByPage(@RequestBody TailPageRequest request,
+                                                              @RequestHeader(AUTHORIZATION) String authorizationHeader)
+            throws UserNotFoundException, TailTypeNotFoundException, TailLevelNotFoundException, TailStatusNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.info("User {} (ID: {}) requesting page of tails with request: {}", currentUser.getUsername(), currentUser.getId(), request);
+        Page<TailResponse> tails = tailService.getTails(request, currentUser);
+        return ResponseEntity.ok(tails);
     }
 
     @Operation(summary = "Get top 9 newest tails", responses = {
@@ -64,19 +83,37 @@ public class TailController {
                     content = @Content(schema = @Schema(implementation = TailResponse.class)))
     })
     @GetMapping("/top9")
-    public ResponseEntity<List<TailResponse>> getTop9NewestTails() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO THEIR ORGANIZATION
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-        return ResponseEntity.ok(tailService.getTop9NewestTails());
+    public ResponseEntity<List<TailResponse>> getTop9NewestTails(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.info("User {} (ID: {}) requesting top 9 newest tails.", currentUser.getUsername(), currentUser.getId());
+        List<TailResponse> tails = tailService.getTop9NewestTails(currentUser);
+        return ResponseEntity.ok(tails);
     }
 
     @Operation(summary = "Mark tail as resolved", responses = {
             @ApiResponse(responseCode = "204", description = "Tail resolved"),
+            @ApiResponse(responseCode = "403", description = "Access denied",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Tail or tail status not found")
     })
     @PostMapping("/mark/resolved")
-    public ResponseEntity<Void> markTailResolved(@RequestBody ResolveTailRequest request) throws TailNotFoundException, TailStatusNotFoundException {
-        // TODO MAKE SURE ONLY ASSIGNED USER OR AN ORGANIZATION ADMIN CAN MARK THE TAIL AS RESOLVED
+    public ResponseEntity<Void> markTailResolved(@RequestBody ResolveTailRequest request,
+                                                 @RequestHeader(AUTHORIZATION) String authorizationHeader)
+            throws UserNotFoundException, AccessDeniedException, TailNotFoundException, TailStatusNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        TailResponse tail = tailService.getTailById(request.getTailId()); // Fetch tail to check ownership/admin rights
+
+        boolean isAssigned = tail.getAssignedUserId() != null && currentUser.getId().equals(tail.getAssignedUserId());
+        boolean isAdmin = authorizationService.isOrganizationAdmin(currentUser, tail.getOrganizationId());
+
+        if (!(isAssigned || isAdmin)) {
+            log.warn("User {} (ID: {}) attempted to mark tail {} as resolved. User is not assigned ({}) nor admin of organization {}.",
+                    currentUser.getUsername(), currentUser.getId(), request.getTailId(), tail.getAssignedUserId(), tail.getOrganizationId());
+            throw new AccessDeniedException("User cannot mark this tail as resolved. Must be assigned user or organization admin.");
+        }
+
+        log.info("User {} (ID: {}) marking tail {} as resolved. IsAssigned: {}, IsAdmin: {}",
+                currentUser.getUsername(), currentUser.getId(), request.getTailId(), isAssigned, isAdmin);
         tailService.markResolved(request);
         return ResponseEntity.noContent().build();
     }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailMetricsController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailMetricsController.java
@@ -1,7 +1,10 @@
 package com.n1netails.n1netails.api.controller;
 
+import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.request.TimezoneRequest;
 import com.n1netails.n1netails.api.model.response.*;
+import com.n1netails.n1netails.api.service.AuthorizationService;
 import com.n1netails.n1netails.api.service.TailMetricsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -12,15 +15,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -31,17 +31,17 @@ import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATIO
 public class TailMetricsController {
 
     private final TailMetricsService tailMetricsService;
+    private final AuthorizationService authorizationService;
 
     @Operation(summary = "Get tail alerts that occurred today.", responses = {
             @ApiResponse(responseCode = "200", description = "List of tail alerts",
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailResponse.class))))
     })
     @PostMapping("/today")
-    public List<TailResponse> getTailAlertsToday(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.tailAlertsToday(timezoneRequest.getTimezone());
+    public List<TailResponse> getTailAlertsToday(@RequestHeader(AUTHORIZATION) String authorizationHeader,
+                                                 @RequestBody TimezoneRequest timezoneRequest) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.tailAlertsToday(timezoneRequest.getTimezone(), currentUser);
     }
 
     @Operation(summary = "Count tail alerts that occurred today.", responses = {
@@ -49,11 +49,10 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @PostMapping("/today/count")
-    public long countTailAlertsToday(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.countAlertsToday(timezoneRequest.getTimezone());
+    public long countTailAlertsToday(@RequestHeader(AUTHORIZATION) String authorizationHeader,
+                                     @RequestBody TimezoneRequest timezoneRequest) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.countAlertsToday(timezoneRequest.getTimezone(), currentUser);
     }
 
     @Operation(summary = "Get tail alerts that are resolved.", responses = {
@@ -61,11 +60,9 @@ public class TailMetricsController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailResponse.class))))
     })
     @GetMapping("/resolved")
-    public List<TailResponse> getTailAlertsResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.tailAlertsResolved();
+    public List<TailResponse> getTailAlertsResolved(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.tailAlertsResolved(currentUser);
     }
 
     @Operation(summary = "Count tail alerts that are resolved.", responses = {
@@ -73,11 +70,9 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @GetMapping("/resolved/count")
-    public long countTailAlertsResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.countAlertsResolved();
+    public long countTailAlertsResolved(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.countAlertsResolved(currentUser);
     }
 
     @Operation(summary = "Get tail alerts that are not resolved.", responses = {
@@ -85,11 +80,9 @@ public class TailMetricsController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailResponse.class))))
     })
     @GetMapping("/not-resolved")
-    public List<TailResponse> getTailAlertsNotResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.tailAlertsNotResolved();
+    public List<TailResponse> getTailAlertsNotResolved(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.tailAlertsNotResolved(currentUser);
     }
 
     @Operation(summary = "Count tail alerts that are not resolved.", responses = {
@@ -97,11 +90,9 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @GetMapping("/not-resolved/count")
-    public long countTailAlertsNotResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.countAlertsNotResolved();
+    public long countTailAlertsNotResolved(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.countAlertsNotResolved(currentUser);
     }
 
     @Operation(summary = "Tail Alert Mean Time to Resolve.", responses = {
@@ -109,11 +100,9 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @GetMapping("/mttr")
-    public long getTailAlertsMTTR() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.tailAlertsMTTR();
+    public long getTailAlertsMTTR(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.tailAlertsMTTR(currentUser);
     }
 
     @Operation(summary = "Get MTTR for the last 7 days.", responses = {
@@ -121,11 +110,9 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = TailDatasetMttrResponse.class)))
     })
     @GetMapping("/mttr/last-7-days")
-    public TailDatasetMttrResponse getTailMTTRLast7Days() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.getTailMTTRLast7Days();
+    public TailDatasetMttrResponse getTailMTTRLast7Days(@RequestHeader(AUTHORIZATION) String authorizationHeader) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.getTailMTTRLast7Days(currentUser);
     }
 
     @Operation(summary = "Get tail alerts count per hour for the last 9 hours.", responses = {
@@ -133,11 +120,10 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = TailAlertsPerHourResponse.class)))
     })
     @PostMapping("/hourly")
-    public TailAlertsPerHourResponse getTailAlertsHourly(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.getTailAlertsPerHour(timezoneRequest.getTimezone());
+    public TailAlertsPerHourResponse getTailAlertsHourly(@RequestHeader(AUTHORIZATION) String authorizationHeader,
+                                                         @RequestBody TimezoneRequest timezoneRequest) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.getTailAlertsPerHour(timezoneRequest.getTimezone(), currentUser);
     }
 
     @Operation(summary = "Get a monthly summary of tail alerts for the past 28 days, categorized by level.", responses = {
@@ -145,10 +131,9 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = TailMonthlySummaryResponse.class)))
     })
     @PostMapping("/monthly-summary")
-    public TailMonthlySummaryResponse getTailMonthlySummary(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
-
-        return tailMetricsService.getTailMonthlySummary(timezoneRequest.getTimezone());
+    public TailMonthlySummaryResponse getTailMonthlySummary(@RequestHeader(AUTHORIZATION) String authorizationHeader,
+                                                            @RequestBody TimezoneRequest timezoneRequest) throws UserNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        return tailMetricsService.getTailMonthlySummary(timezoneRequest.getTimezone(), currentUser);
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/UserController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/UserController.java
@@ -5,17 +5,22 @@ import com.n1netails.n1netails.api.exception.type.InvalidRoleException;
 import com.n1netails.n1netails.api.exception.type.PasswordRegexException;
 import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
 import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
 import com.n1netails.n1netails.api.model.entity.UsersEntity;
 import com.n1netails.n1netails.api.model.request.UpdateUserRoleRequest;
 import com.n1netails.n1netails.api.model.request.UserLoginRequest;
 import com.n1netails.n1netails.api.model.request.UserRegisterRequest;
 import com.n1netails.n1netails.api.model.response.HttpErrorResponse;
+import com.n1netails.n1netails.api.repository.UserRepository;
+import com.n1netails.n1netails.api.service.AuthorizationService;
 import com.n1netails.n1netails.api.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+// import java.nio.file.AccessDeniedException; // Replaced by Spring Security's AccessDeniedException
+import org.springframework.security.access.AccessDeniedException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,13 +33,16 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.*;
 import org.springframework.web.bind.annotation.*;
 
-import java.nio.file.AccessDeniedException;
+// import java.nio.file.AccessDeniedException; // Already handled above
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Set;
+
 
 import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
 import static com.n1netails.n1netails.api.constant.ProjectSecurityConstant.*;
+import com.n1netails.n1netails.api.constant.Authority; // For ROLE_SUPER_ADMIN comparison
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -45,10 +53,14 @@ import static org.springframework.http.HttpStatus.OK;
 @RequestMapping(path = {"/ninetails/user"}, produces = APPLICATION_JSON)
 public class UserController {
 
+    private static final String N1NETAILS_ORGANIZATION_NAME = "n1netails"; // Constant for organization name
+
     private final UserService userService;
     private final AuthenticationManager authenticationManager;
     private final JwtEncoder jwtEncoder;
     private final JwtDecoder jwtDecoder;
+    private final AuthorizationService authorizationService; // Injected
+    private final UserRepository userRepository; // Injected
 
     @Operation(
             summary = "Edit user profile",
@@ -64,20 +76,19 @@ public class UserController {
     public ResponseEntity<UsersEntity> editUser(
             @RequestHeader(AUTHORIZATION) String authorizationHeader,
             @RequestBody UsersEntity user
-    ) throws AccessDeniedException {
-        try {
-            String token = authorizationHeader.substring(TOKEN_PREFIX.length());
-            String authEmail = jwtDecoder.decode(token).getSubject();
+    ) throws AccessDeniedException, UserNotFoundException { // Added UserNotFoundException for getCurrentUserPrincipal
+        // It's generally better to edit based on ID from token, not email from request body if that's an option.
+        // Assuming user.getEmail() is the target user's email.
+        UserPrincipal editingPrincipal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
 
-            if (authEmail.equals(user.getEmail())) {
-                log.info("auth email: {}", authEmail);
-                UsersEntity editUser = userService.editUser(user);
-                return new ResponseEntity<>(editUser, OK);
-            } else {
-                throw new AccessDeniedException(ACCESS_DENIED_MESSAGE);
-            }
-        } catch (JwtException e) {
-            throw new AccessDeniedException(ACCESS_DENIED_MESSAGE);
+        // Basic check: user can only edit their own profile through this specific endpoint
+        if (editingPrincipal.getUsername().equals(user.getEmail())) {
+            log.info("User {} editing their own profile.", editingPrincipal.getUsername());
+            UsersEntity editUser = userService.editUser(user); // userService.editUser should ensure it's loading by ID or a unique field
+            return new ResponseEntity<>(editUser, OK);
+        } else {
+            log.warn("User {} attempted to edit profile of user {} via /edit endpoint.", editingPrincipal.getUsername(), user.getEmail());
+            throw new AccessDeniedException("You can only edit your own profile using this endpoint.");
         }
     }
 
@@ -129,12 +140,54 @@ public class UserController {
     }
 
     @PutMapping("/{userId}/role")
-    @PreAuthorize("hasAuthority('user:super')") // 'user:super' is unique to SUPER_ADMIN_AUTHORITIES
-    public ResponseEntity<?> updateUserRole(@PathVariable Long userId, @Valid @RequestBody UpdateUserRoleRequest updateUserRoleRequest) throws UserNotFoundException, InvalidRoleException {
-        // TODO ENSURE THAT SUPER USERS ROLE CANNOT BE CHANGED
-        // TODO ENSURE THAT SUPER USERS ARE ONLY PART OF THE n1netails ORGANIZATION
+    @PreAuthorize("hasAuthority('user:super')")
+    public ResponseEntity<UsersEntity> updateUserRole(@RequestHeader(AUTHORIZATION) String authorizationHeader,
+                                                      @PathVariable Long userId,
+                                                      @Valid @RequestBody UpdateUserRoleRequest updateUserRoleRequest)
+            throws UserNotFoundException, InvalidRoleException, AccessDeniedException {
+
+        UserPrincipal adminPrincipal = authorizationService.getCurrentUserPrincipal(authorizationHeader); // Admin making the call
+        log.info("Admin {} attempting to update role for user ID: {} to role: {}", adminPrincipal.getUsername(), userId, updateUserRoleRequest.getRoleName());
+
+        UsersEntity targetUserEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("Target user with ID " + userId + " not found."));
+        UserPrincipal targetUserPrincipal = new UserPrincipal(targetUserEntity);
+
+        // Authorization Check 1: Prevent changing Super Admin's role.
+        if (authorizationService.isSuperAdmin(targetUserPrincipal)) {
+            log.warn("Admin {} attempted to change the role of Super Admin user {}", adminPrincipal.getUsername(), targetUserPrincipal.getUsername());
+            throw new AccessDeniedException("Cannot change the role of a Super Admin.");
+        }
+
+        // Authorization Check 2: If making a user Super Admin, they must belong exclusively to "n1netails" org.
+        if (isNewRoleSuperAdmin(updateUserRoleRequest.getRoleName())) {
+            log.info("Attempting to promote user {} to Super Admin. Checking organization membership.", targetUserPrincipal.getUsername());
+            Set<OrganizationEntity> targetUserOrgs = targetUserPrincipal.getOrganizations();
+            boolean targetIsInOnlyN1netailsOrg = targetUserOrgs.stream()
+                    .anyMatch(org -> N1NETAILS_ORGANIZATION_NAME.equals(org.getName())) && targetUserOrgs.size() == 1;
+
+            if (!targetIsInOnlyN1netailsOrg) {
+                log.warn("User {} cannot be made Super Admin. They belong to {} organizations, must be exclusively in '{}'. Organizations: {}",
+                        targetUserPrincipal.getUsername(), targetUserOrgs.size(), N1NETAILS_ORGANIZATION_NAME,
+                        targetUserOrgs.stream().map(OrganizationEntity::getName).collect(Collectors.toList()));
+                throw new AccessDeniedException("User must belong exclusively to the '" + N1NETAILS_ORGANIZATION_NAME + "' organization to become a Super Admin.");
+            }
+            log.info("User {} meets organization criteria for Super Admin promotion.", targetUserPrincipal.getUsername());
+        }
+
         UsersEntity updatedUser = userService.updateUserRole(userId, updateUserRoleRequest.getRoleName());
+        log.info("User {} role updated to {} by admin {}", updatedUser.getEmail(), updatedUser.getRole(), adminPrincipal.getUsername());
         return ResponseEntity.ok(updatedUser);
+    }
+
+    private boolean isNewRoleSuperAdmin(String roleNameFromRequest) {
+        // This logic depends on how role names map to the "user:super" authority.
+        // Assuming "ROLE_SUPER_ADMIN" is the role name that grants SUPER_ADMIN_AUTHORITIES.
+        // This might need adjustment if the actual role name for super admin is different
+        // or if it's based on the authorities directly.
+        // For simplicity, using a direct string comparison. A more robust way might involve
+        // checking the authorities granted by this roleNameFromRequest if that mapping is available here.
+        return "ROLE_SUPER_ADMIN".equalsIgnoreCase(roleNameFromRequest); // Example, adjust if Authority enum has role names
     }
 
     private void authenticate(String email, String password) {

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/TailEntity.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/TailEntity.java
@@ -47,4 +47,8 @@ public class TailEntity {
     @ManyToOne
     @JoinColumn(name = "organization_id")
     private OrganizationEntity organization;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id") // Represents the owner of the tail
+    private UsersEntity user;
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/TailResponse.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/TailResponse.java
@@ -12,11 +12,15 @@ import java.util.Map;
 @NoArgsConstructor
 public class TailResponse {
     private Long id;
+    // Fields needed for controller authorization logic
+    private Long userId; // Owner of the tail
+    private Long organizationId; // Organization this tail belongs to
+
     private String title;
     private String description;
     private Instant timestamp;
     private Instant resolvedTimestamp;
-    private Long assignedUserId;
+    private Long assignedUserId; // User assigned to resolve the tail
     private String assignedUsername;
     private String details;
     private String level;

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/N1neTokenRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/N1neTokenRepository.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Repository
@@ -13,4 +14,5 @@ public interface N1neTokenRepository extends JpaRepository<N1neTokenEntity, Long
 
     List<N1neTokenEntity> findByUserId(Long userId);
     Optional<N1neTokenEntity> findByToken(UUID token);
+    List<N1neTokenEntity> findByOrganization_IdIn(Set<Long> organizationIds); // New method
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailRepository.java
@@ -8,14 +8,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 @Repository
-public interface TailRepository extends JpaRepository<TailEntity, Long> {
+public interface TailRepository extends JpaRepository<TailEntity, Long>, JpaSpecificationExecutor<TailEntity> {
+
+    // Added for getTop9NewestTails authorization logic
+    List<TailEntity> findByOrganization_IdInAndUser_IdOrderByCreatedAtDesc(Collection<Long> organizationIds, Long userId, Pageable pageable);
+    List<TailEntity> findByOrganization_IdInOrderByCreatedAtDesc(Collection<Long> organizationIds, Pageable pageable);
 
     @Query("""
         SELECT new com.n1netails.n1netails.api.model.dto.TailSummary(
@@ -70,33 +77,100 @@ public interface TailRepository extends JpaRepository<TailEntity, Long> {
 
     List<TailEntity> findByAssignedUserId(Long userId);
 
-    long countByTimestampBetween(Instant startOfDay, Instant endOfDay);
-    List<TailEntity> findByTimestampBetween(Instant startOfDay, Instant endOfDay);
+    // Methods for TailMetricsService authorization
+    @Query("SELECT t FROM TailEntity t WHERE t.timestamp BETWEEN :startOfDay AND :endOfDay AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    List<TailEntity> findByTimestampBetweenAndOrganizationIdsAndOptionalUserId(
+            @Param("startOfDay") Instant startOfDay,
+            @Param("endOfDay") Instant endOfDay,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
 
-    @Query("SELECT t.timestamp FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end ORDER BY t.timestamp ASC")
-    List<Instant> findOnlyTimestampsBetween(
+    @Query("SELECT COUNT(t) FROM TailEntity t WHERE t.timestamp BETWEEN :startOfDay AND :endOfDay AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    long countByTimestampBetweenAndOrganizationIdsAndOptionalUserId(
+            @Param("startOfDay") Instant startOfDay,
+            @Param("endOfDay") Instant endOfDay,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
+
+    @Query("SELECT t FROM TailEntity t WHERE t.status.name = :statusName AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    List<TailEntity> findAllByStatusNameAndOrganizationIdsAndOptionalUserId(
+            @Param("statusName") String statusName,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
+
+    @Query("SELECT COUNT(t) FROM TailEntity t WHERE t.status.name = :statusName AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    long countByStatusNameAndOrganizationIdsAndOptionalUserId(
+            @Param("statusName") String statusName,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
+
+    @Query("SELECT t FROM TailEntity t WHERE t.status.name <> :statusName AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    List<TailEntity> findAllByStatusNameNotAndOrganizationIdsAndOptionalUserId(
+            @Param("statusName") String statusName,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
+
+    @Query("SELECT COUNT(t) FROM TailEntity t WHERE t.status.name <> :statusName AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    long countByStatusNameNotAndOrganizationIdsAndOptionalUserId(
+            @Param("statusName") String statusName,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
+           "FROM TailEntity t WHERE t.resolvedTimestamp IS NOT NULL AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    List<TailTimestampAndResolvedTimestamp> findTimestampsForMTTRCalculation(
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
+           "FROM TailEntity t WHERE t.resolvedTimestamp IS NOT NULL AND t.timestamp >= :daysAgo AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId)")
+    List<TailTimestampAndResolvedTimestamp> findTimestampsForMTTRLast7Days(
+            @Param("daysAgo") Instant daysAgo,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
+    );
+
+    @Query("SELECT t.timestamp FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId) ORDER BY t.timestamp ASC")
+    List<Instant> findTimestampsBetweenForHourly(
             @Param("start") Instant start,
-            @Param("end") Instant end
+            @Param("end") Instant end,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
     );
 
     @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailLevelAndTimestamp(t.timestamp, t.level) " +
-            "FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end ORDER BY t.timestamp ASC")
-    List<TailLevelAndTimestamp> findOnlyLevelAndTimestampsBetween(
+           "FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end AND t.organization.id IN :orgIds AND (:userId IS NULL OR t.user.id = :userId) ORDER BY t.timestamp ASC")
+    List<TailLevelAndTimestamp> findLevelAndTimestampsBetweenForMonthlySummary(
             @Param("start") Instant start,
-            @Param("end") Instant end
+            @Param("end") Instant end,
+            @Param("orgIds") Set<Long> orgIds,
+            @Param("userId") Long userId
     );
 
-    List<TailEntity> findAllByStatusName(String statusName);
-    long countByStatusName(String statusName);
+    // Keep existing non-metric related methods
+    long countByTimestampBetween(Instant startOfDay, Instant endOfDay); // Might be unused now or used by other services
+    List<TailEntity> findByTimestampBetween(Instant startOfDay, Instant endOfDay); // Might be unused now or used by other services
+    @Query("SELECT t.timestamp FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end ORDER BY t.timestamp ASC")
+    List<Instant> findOnlyTimestampsBetween(@Param("start") Instant start, @Param("end") Instant end); // Might be unused
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailLevelAndTimestamp(t.timestamp, t.level) " +
+            "FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end ORDER BY t.timestamp ASC")
+    List<TailLevelAndTimestamp> findOnlyLevelAndTimestampsBetween(@Param("start") Instant start, @Param("end") Instant end); // Might be unused
 
-    List<TailEntity> findAllByStatusNameNot(String statusName);
-    long countByStatusNameNot(String statusName);
-
+    List<TailEntity> findAllByStatusName(String statusName); // Might be unused
+    long countByStatusName(String statusName); // Might be unused
+    List<TailEntity> findAllByStatusNameNot(String statusName); // Might be unused
+    long countByStatusNameNot(String statusName); // Might be unused
     @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
             "FROM TailEntity t WHERE t.resolvedTimestamp IS NOT NULL")
-    List<TailTimestampAndResolvedTimestamp> findOnlyTimestampAndResolvedTimestampIsNotNull();
-
+    List<TailTimestampAndResolvedTimestamp> findOnlyTimestampAndResolvedTimestampIsNotNull(); // Might be unused
     @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
             "FROM TailEntity t WHERE t.resolvedTimestamp IS NOT NULL AND t.timestamp >= :daysAgo")
-    List<TailTimestampAndResolvedTimestamp> findAllByTimestampAfterAndResolvedTimestampIsNotNull(@Param("daysAgo") Instant daysAgo);
+    List<TailTimestampAndResolvedTimestamp> findAllByTimestampAfterAndResolvedTimestampIsNotNull(@Param("daysAgo") Instant daysAgo); // Might be unused
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/AuthorizationService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/AuthorizationService.java
@@ -1,10 +1,24 @@
 package com.n1netails.n1netails.api.service;
 
 import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
-
+import com.n1netails.n1netails.api.model.UserPrincipal;
 
 public interface AuthorizationService {
 
+    UserPrincipal getCurrentUserPrincipal(String authorizationHeader) throws UserNotFoundException;
+
+    boolean isOrganizationAdmin(UserPrincipal principal, Long organizationId);
+
+    boolean isSuperAdmin(UserPrincipal principal);
+
+    boolean belongsToOrganization(UserPrincipal principal, Long organizationId);
+
+    boolean isTailOwner(UserPrincipal principal, Long tailUserId);
+
     boolean isSelf(String authorizationHeader, Long userId) throws UserNotFoundException;
-    boolean isOwnerOrOrganizationAdmin(String authorizationHeader, Long userId, Long organizationId) throws UserNotFoundException;
+
+    // Overloaded isSelf method for convenience when UserPrincipal is already available
+    boolean isSelf(UserPrincipal principal, Long userIdToCheck);
+
+    boolean isOwnerOrOrganizationAdmin(UserPrincipal principal, Long ownerUserId, Long organizationId);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/N1neTokenService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/N1neTokenService.java
@@ -5,12 +5,15 @@ import com.n1netails.n1netails.api.model.request.CreateTokenRequest;
 import com.n1netails.n1netails.api.model.response.N1neTokenResponse;
 
 import java.util.List;
+import java.util.Set;
 
 public interface N1neTokenService {
 
     N1neTokenResponse create(CreateTokenRequest createTokenRequest);
     N1neTokenResponse getById(Long id);
-    List<N1neTokenResponse> getAll();
+    // List<N1neTokenResponse> getAll(); // Replaced by getAllTokens and getAllTokensForOrganizations
+    List<N1neTokenResponse> getAllTokens(); // For Super Admins
+    List<N1neTokenResponse> getAllTokensForOrganizations(Set<Long> organizationIds); // For Org Admins
     List<N1neTokenResponse> getAllByUserId(Long userId);
     void revoke(Long id);
     void enable(Long id);

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailMetricsService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailMetricsService.java
@@ -1,25 +1,26 @@
 package com.n1netails.n1netails.api.service;
 
+import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.response.*;
 
 import java.util.List;
 
 public interface TailMetricsService {
 
-    List<TailResponse> tailAlertsToday(String timezone);
-    long countAlertsToday(String timezone);
+    List<TailResponse> tailAlertsToday(String timezone, UserPrincipal currentUser);
+    long countAlertsToday(String timezone, UserPrincipal currentUser);
 
-    List<TailResponse> tailAlertsResolved();
-    long countAlertsResolved();
+    List<TailResponse> tailAlertsResolved(UserPrincipal currentUser);
+    long countAlertsResolved(UserPrincipal currentUser);
 
-    List<TailResponse> tailAlertsNotResolved();
-    long countAlertsNotResolved();
+    List<TailResponse> tailAlertsNotResolved(UserPrincipal currentUser);
+    long countAlertsNotResolved(UserPrincipal currentUser);
 
-    long tailAlertsMTTR();
+    long tailAlertsMTTR(UserPrincipal currentUser);
 
-    TailAlertsPerHourResponse getTailAlertsPerHour(String timezone);
+    TailAlertsPerHourResponse getTailAlertsPerHour(String timezone, UserPrincipal currentUser);
 
-    TailMonthlySummaryResponse getTailMonthlySummary(String timezone);
+    TailMonthlySummaryResponse getTailMonthlySummary(String timezone, UserPrincipal currentUser);
 
-    TailDatasetMttrResponse getTailMTTRLast7Days();
+    TailDatasetMttrResponse getTailMTTRLast7Days(UserPrincipal currentUser);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailService.java
@@ -4,6 +4,7 @@ import com.n1netails.n1netails.api.exception.type.TailLevelNotFoundException;
 import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
 import com.n1netails.n1netails.api.exception.type.TailStatusNotFoundException;
 import com.n1netails.n1netails.api.exception.type.TailTypeNotFoundException;
+import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.core.TailStatus;
 import com.n1netails.n1netails.api.model.request.ResolveTailRequest;
 import com.n1netails.n1netails.api.model.request.TailPageRequest;
@@ -14,8 +15,8 @@ import java.util.List;
 
 public interface TailService {
 
-    Page<TailResponse> getTails(TailPageRequest request) throws TailStatusNotFoundException, TailTypeNotFoundException, TailLevelNotFoundException;
-    List<TailResponse> getTop9NewestTails();
+    Page<TailResponse> getTails(TailPageRequest request, UserPrincipal currentUser) throws TailStatusNotFoundException, TailTypeNotFoundException, TailLevelNotFoundException;
+    List<TailResponse> getTop9NewestTails(UserPrincipal currentUser);
     TailResponse getTailById(Long id);
 
     TailResponse updateStatus(Long id, TailStatus tailStatus);

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/AuthorizationServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/AuthorizationServiceImpl.java
@@ -6,19 +6,20 @@ import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
 import com.n1netails.n1netails.api.model.entity.UsersEntity;
 import com.n1netails.n1netails.api.repository.UserRepository;
+import org.springframework.security.core.GrantedAuthority;
 import com.n1netails.n1netails.api.service.AuthorizationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Optional;
 
 import static com.n1netails.n1netails.api.constant.ProjectSecurityConstant.TOKEN_PREFIX;
 
@@ -32,40 +33,101 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     private final JwtDecoder jwtDecoder;
 
     @Override
-    public boolean isSelf(String authorizationHeader, Long userId) throws UserNotFoundException {
-        UserPrincipal principal = getUserPrincipal(authorizationHeader, userId);
+    public UserPrincipal getCurrentUserPrincipal(String authorizationHeader) throws UserNotFoundException {
+        log.debug("Attempting to get current user principal from authorization header.");
+        String token = authorizationHeader.replace(TOKEN_PREFIX, "");
+        String authEmail = jwtDecoder.decode(token).getSubject();
+        log.info("Decoded email from token: {}", authEmail);
 
-        log.info("is self {}", Objects.equals(principal.getId(), userId));
-        return Objects.equals(principal.getId(), userId);
+        UsersEntity currentUser = userRepository.findUserByEmail(authEmail)
+                .orElseThrow(() -> {
+                    log.warn("User not found for email: {}", authEmail);
+                    return new UserNotFoundException("User not found by provided email from token.");
+                });
+        log.debug("User entity found for email: {}", authEmail);
+        return new UserPrincipal(currentUser);
     }
 
     @Override
-    public boolean isOwnerOrOrganizationAdmin(String authorizationHeader, Long userId, Long organizationId) throws UserNotFoundException {
-        UserPrincipal principal = getUserPrincipal(authorizationHeader, userId);
+    public boolean isOrganizationAdmin(UserPrincipal principal, Long organizationId) {
+        log.debug("Checking if user {} is admin for organization {}", principal.getUsername(), organizationId);
+        boolean isAdmin = principal.getAuthorities().contains(new SimpleGrantedAuthority("user:admin")) &&
+                principal.getOrganizations().stream()
+                        .map(OrganizationEntity::getId)
+                        .anyMatch(id -> id.equals(organizationId));
+        log.info("User {} is{} admin for organization {}", principal.getUsername(), isAdmin ? "" : " not", organizationId);
+        return isAdmin;
+    }
 
-        log.info("Authorities: {}", principal.getAuthorities().stream().toList());
-        Set<OrganizationEntity> organizationEntitySet = principal.getOrganizations();
-        List<Long> organizationIds = organizationEntitySet.stream().map(OrganizationEntity::getId).toList();
-        if (Objects.equals(principal.getId(), userId)) {
+    @Override
+    public boolean isSuperAdmin(UserPrincipal principal) {
+        log.debug("Checking if user {} is super admin", principal.getUsername());
+        boolean isSuper = principal.getAuthorities().contains(new SimpleGrantedAuthority("user:super"));
+        log.info("User {} is{} super admin", principal.getUsername(), isSuper ? "" : " not");
+        return isSuper;
+    }
+
+    @Override
+    public boolean belongsToOrganization(UserPrincipal principal, Long organizationId) {
+        log.debug("Checking if user {} belongs to organization {}", principal.getUsername(), organizationId);
+        boolean belongs = principal.getOrganizations().stream()
+                .map(OrganizationEntity::getId)
+                .anyMatch(id -> id.equals(organizationId));
+        log.info("User {} {} to organization {}", principal.getUsername(), belongs ? "belongs" : "does not belong", organizationId);
+        return belongs;
+    }
+
+    @Override
+    public boolean isTailOwner(UserPrincipal principal, Long tailUserId) {
+        log.debug("Checking if user {} is owner of tail with user ID {}", principal.getUsername(), tailUserId);
+        boolean isOwner = Objects.equals(principal.getId(), tailUserId);
+        log.info("User {} is{} owner of tail with user ID {}", principal.getUsername(), isOwner ? "" : " not", tailUserId);
+        return isOwner;
+    }
+
+
+    @Override
+    public boolean isSelf(String authorizationHeader, Long userId) throws UserNotFoundException {
+        UserPrincipal principal = getCurrentUserPrincipal(authorizationHeader);
+        log.info("is self check for user ID {} against principal ID {}", userId, principal.getId());
+        return Objects.equals(principal.getId(), userId);
+    }
+
+    // Overloaded isSelf method
+    public boolean isSelf(UserPrincipal principal, Long userIdToCheck) {
+        log.info("is self check for user ID {} against principal ID {}", userIdToCheck, principal.getId());
+        return Objects.equals(principal.getId(), userIdToCheck);
+    }
+
+
+    @Override
+    public boolean isOwnerOrOrganizationAdmin(UserPrincipal principal, Long ownerUserId, Long organizationId) {
+        log.debug("Checking if user {} is owner (ID: {}) or admin for organization {}", principal.getUsername(), ownerUserId, organizationId);
+        if (isSelf(principal, ownerUserId)) {
+            log.info("User {} is owner (ID: {})", principal.getUsername(), ownerUserId);
             return true;
-        } else if (principal.getAuthorities().contains(new SimpleGrantedAuthority("user:admin")) && organizationIds.contains(organizationId)) {
-            return true;
-        } else {
-            return false;
         }
+        if (isOrganizationAdmin(principal, organizationId)) {
+            log.info("User {} is admin for organization {}", principal.getUsername(), organizationId);
+            return true;
+        }
+        log.info("User {} is neither owner (ID: {}) nor admin for organization {}", principal.getUsername(), ownerUserId, organizationId);
+        return false;
     }
 
-    private UserPrincipal getUserPrincipal(String authorizationHeader, Long userId) throws UserNotFoundException {
-        log.info("USER ID: {}", userId);
-        String token = authorizationHeader.substring(TOKEN_PREFIX.length());
-        String authEmail = jwtDecoder.decode(token).getSubject();
-        log.info("JWT AUTH EMAL: {}", authEmail);
-        String claims = jwtDecoder.decode(token).getClaims().toString();
-        log.info("JWT CLAIMS: {}", claims);
+    // This private helper method is no longer needed as getCurrentUserPrincipal serves a similar purpose
+    // and other methods now accept UserPrincipal directly.
+    // private UserPrincipal getUserPrincipal(String authorizationHeader, Long userId) throws UserNotFoundException {
+    //     log.info("USER ID: {}", userId);
+    //     String token = authorizationHeader.substring(TOKEN_PREFIX.length());
+    //     String authEmail = jwtDecoder.decode(token).getSubject();
+    //     log.info("JWT AUTH EMAL: {}", authEmail);
+    //     String claims = jwtDecoder.decode(token).getClaims().toString();
+    //     log.info("JWT CLAIMS: {}", claims);
 
-        UsersEntity currentUser = this.userRepository.findUserByEmail(authEmail)
-                .orElseThrow(() -> new UserNotFoundException("User not found by provided email."));
+    //     UsersEntity currentUser = this.userRepository.findUserByEmail(authEmail)
+    //             .orElseThrow(() -> new UserNotFoundException("User not found by provided email."));
 
-        return new UserPrincipal(currentUser);
-    }
+    //     return new UserPrincipal(currentUser);
+    // }
 }


### PR DESCRIPTION
I've implemented comprehensive authorization checks across multiple controllers to address pending TODOs and enhance security.

Key changes include:

- Enhanced `AuthorizationServiceImpl` with new methods for granular permission checking (e.g., `isOrganizationAdmin`, `isSuperAdmin`, `isTailOwner`, `belongsToOrganization`).
- Refactored `OrganizationController`, `TailController`, `TailMetricsController`, `UserController`, and `N1neTokenController` to utilize `AuthorizationService` instead of relying solely on `@AuthenticationPrincipal` or broad `@PreAuthorize` annotations.
- `TailService` and `TailMetricsService` now filter data based on your organizational affiliations and specific rules for the "n1netails" organization (you see only your own data).
- `TailRepository` and `N1neTokenRepository` were updated with new query methods to support this filtered data retrieval.
- `UserController.updateUserRole` now prevents modifications to Super Admins and ensures users being promoted to Super Admin belong exclusively to the "n1netails" organization.
- The `N1neTokenController.getAll()` endpoint now allows Super Admins to view all tokens and Organization Admins to view tokens within their managed organizations.
- Ensured consistent use of `UserPrincipal` for authorization decisions throughout the affected controllers.