### PR TITLE
Refactor: Isolate Tail Metrics Repository and Restrict Metrics Access

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailMetricsController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailMetricsController.java
@@ -1,7 +1,11 @@
 package com.n1netails.n1netails.api.controller;
 
 import com.n1netails.n1netails.api.model.request.TimezoneRequest;
+import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
+import com.n1netails.n1netails.api.model.request.TimezoneRequest;
 import com.n1netails.n1netails.api.model.response.*;
+import com.n1netails.n1netails.api.service.AuthorizationService;
 import com.n1netails.n1netails.api.service.TailMetricsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -15,15 +19,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
+import static com.n1netails.n1netails.api.constant.ProjectSecurityConstant.JWT_TOKEN_HEADER;
 
 @Slf4j
-@RequiredArgsConstructor
 @Tag(name = "Tail Metrics Controller", description = "Operations related to Tail Metrics")
 @SecurityRequirement(name = "bearerAuth")
 @RestController
@@ -31,17 +37,31 @@ import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATIO
 public class TailMetricsController {
 
     private final TailMetricsService tailMetricsService;
+    private final AuthorizationService authorizationService;
+
+    public TailMetricsController(TailMetricsService tailMetricsService, AuthorizationService authorizationService) {
+        this.tailMetricsService = tailMetricsService;
+        this.authorizationService = authorizationService;
+    }
 
     @Operation(summary = "Get tail alerts that occurred today.", responses = {
             @ApiResponse(responseCode = "200", description = "List of tail alerts",
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailResponse.class))))
     })
     @PostMapping("/today")
-    public List<TailResponse> getTailAlertsToday(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public List<TailResponse> getTailAlertsToday(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader,
+                                               @RequestBody TimezoneRequest timezoneRequest) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.tailAlertsToday(timezoneRequest.getTimezone());
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.tailAlertsToday(timezoneRequest.getTimezone(), currentUserId, null);
+        } else {
+            return tailMetricsService.tailAlertsToday(timezoneRequest.getTimezone(), null, organizationIds);
+        }
     }
 
     @Operation(summary = "Count tail alerts that occurred today.", responses = {
@@ -49,11 +69,19 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @PostMapping("/today/count")
-    public long countTailAlertsToday(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public long countTailAlertsToday(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader,
+                                     @RequestBody TimezoneRequest timezoneRequest) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.countAlertsToday(timezoneRequest.getTimezone());
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.countAlertsToday(timezoneRequest.getTimezone(), currentUserId, null);
+        } else {
+            return tailMetricsService.countAlertsToday(timezoneRequest.getTimezone(), null, organizationIds);
+        }
     }
 
     @Operation(summary = "Get tail alerts that are resolved.", responses = {
@@ -61,11 +89,18 @@ public class TailMetricsController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailResponse.class))))
     })
     @GetMapping("/resolved")
-    public List<TailResponse> getTailAlertsResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public List<TailResponse> getTailAlertsResolved(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.tailAlertsResolved();
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.tailAlertsResolved(currentUserId, null);
+        } else {
+            return tailMetricsService.tailAlertsResolved(null, organizationIds);
+        }
     }
 
     @Operation(summary = "Count tail alerts that are resolved.", responses = {
@@ -73,11 +108,18 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @GetMapping("/resolved/count")
-    public long countTailAlertsResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public long countTailAlertsResolved(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.countAlertsResolved();
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.countAlertsResolved(currentUserId, null);
+        } else {
+            return tailMetricsService.countAlertsResolved(null, organizationIds);
+        }
     }
 
     @Operation(summary = "Get tail alerts that are not resolved.", responses = {
@@ -85,11 +127,18 @@ public class TailMetricsController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailResponse.class))))
     })
     @GetMapping("/not-resolved")
-    public List<TailResponse> getTailAlertsNotResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public List<TailResponse> getTailAlertsNotResolved(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.tailAlertsNotResolved();
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.tailAlertsNotResolved(currentUserId, null);
+        } else {
+            return tailMetricsService.tailAlertsNotResolved(null, organizationIds);
+        }
     }
 
     @Operation(summary = "Count tail alerts that are not resolved.", responses = {
@@ -97,11 +146,18 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @GetMapping("/not-resolved/count")
-    public long countTailAlertsNotResolved() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public long countTailAlertsNotResolved(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.countAlertsNotResolved();
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.countAlertsNotResolved(currentUserId, null);
+        } else {
+            return tailMetricsService.countAlertsNotResolved(null, organizationIds);
+        }
     }
 
     @Operation(summary = "Tail Alert Mean Time to Resolve.", responses = {
@@ -109,11 +165,18 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = long.class)))
     })
     @GetMapping("/mttr")
-    public long getTailAlertsMTTR() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public long getTailAlertsMTTR(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.tailAlertsMTTR();
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.tailAlertsMTTR(currentUserId, null);
+        } else {
+            return tailMetricsService.tailAlertsMTTR(null, organizationIds);
+        }
     }
 
     @Operation(summary = "Get MTTR for the last 7 days.", responses = {
@@ -121,11 +184,18 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = TailDatasetMttrResponse.class)))
     })
     @GetMapping("/mttr/last-7-days")
-    public TailDatasetMttrResponse getTailMTTRLast7Days() {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public TailDatasetMttrResponse getTailMTTRLast7Days(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.getTailMTTRLast7Days();
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.getTailMTTRLast7Days(currentUserId, null);
+        } else {
+            return tailMetricsService.getTailMTTRLast7Days(null, organizationIds);
+        }
     }
 
     @Operation(summary = "Get tail alerts count per hour for the last 9 hours.", responses = {
@@ -133,11 +203,19 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = TailAlertsPerHourResponse.class)))
     })
     @PostMapping("/hourly")
-    public TailAlertsPerHourResponse getTailAlertsHourly(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public TailAlertsPerHourResponse getTailAlertsHourly(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader,
+                                                       @RequestBody TimezoneRequest timezoneRequest) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.getTailAlertsPerHour(timezoneRequest.getTimezone());
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.getTailAlertsPerHour(timezoneRequest.getTimezone(), currentUserId, null);
+        } else {
+            return tailMetricsService.getTailAlertsPerHour(timezoneRequest.getTimezone(), null, organizationIds);
+        }
     }
 
     @Operation(summary = "Get a monthly summary of tail alerts for the past 28 days, categorized by level.", responses = {
@@ -145,10 +223,18 @@ public class TailMetricsController {
                     content = @Content(schema = @Schema(implementation = TailMonthlySummaryResponse.class)))
     })
     @PostMapping("/monthly-summary")
-    public TailMonthlySummaryResponse getTailMonthlySummary(@RequestBody TimezoneRequest timezoneRequest) {
-        // TODO MAKE SURE USERS CAN ONLY SEE TAILS RELATED TO ORGANIZATIONS THEY ARE APART OF
-        // TODO IF A USER IS PART OF THE n1netails ORGANIZATION THEY CAN ONLY VIEW THEIR OWN TAILS
+    public TailMonthlySummaryResponse getTailMonthlySummary(@RequestHeader(JWT_TOKEN_HEADER) String authorizationHeader,
+                                                          @RequestBody TimezoneRequest timezoneRequest) {
+        UserPrincipal principal = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        Long currentUserId = principal.getId();
+        List<Long> organizationIds = principal.getOrganizations().stream().map(OrganizationEntity::getId).collect(Collectors.toList());
+        boolean isN1neTailsOrgMember = principal.getOrganizations().stream()
+                                           .anyMatch(org -> "n1netails".equalsIgnoreCase(org.getName()));
 
-        return tailMetricsService.getTailMonthlySummary(timezoneRequest.getTimezone());
+        if (isN1neTailsOrgMember) {
+            return tailMetricsService.getTailMonthlySummary(timezoneRequest.getTimezone(), currentUserId, null);
+        } else {
+            return tailMetricsService.getTailMonthlySummary(timezoneRequest.getTimezone(), null, organizationIds);
+        }
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailMetricsRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailMetricsRepository.java
@@ -1,0 +1,73 @@
+package com.n1netails.n1netails.api.repository;
+
+import com.n1netails.n1netails.api.model.dto.TailLevelAndTimestamp;
+import com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp;
+import com.n1netails.n1netails.api.model.entity.TailEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+public interface TailMetricsRepository extends JpaRepository<TailEntity, Long> {
+
+    // Methods for filtering by UserId
+    long countByTimestampBetweenAndUserId(Instant startOfDay, Instant endOfDay, Long userId);
+    List<TailEntity> findByTimestampBetweenAndUserId(Instant startOfDay, Instant endOfDay, Long userId);
+    List<TailEntity> findAllByStatusNameAndUserId(String statusName, Long userId);
+    long countByStatusNameAndUserId(String statusName, Long userId);
+    List<TailEntity> findAllByStatusNameNotAndUserId(String statusName, Long userId);
+    long countByStatusNameNotAndUserId(String statusName, Long userId);
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
+            "FROM TailEntity t WHERE t.resolvedTimestamp IS NOT NULL AND t.userId = :userId")
+    List<TailTimestampAndResolvedTimestamp> findOnlyTimestampAndResolvedTimestampIsNotNullAndUserId(@Param("userId") Long userId);
+
+    @Query("SELECT t.timestamp FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end AND t.userId = :userId ORDER BY t.timestamp ASC")
+    List<Instant> findOnlyTimestampsBetweenAndUserId(@Param("start") Instant start, @Param("end") Instant end, @Param("userId") Long userId);
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailLevelAndTimestamp(t.timestamp, t.level) " +
+            "FROM TailEntity t WHERE t.timestamp BETWEEN :start AND :end AND t.userId = :userId ORDER BY t.timestamp ASC")
+    List<TailLevelAndTimestamp> findOnlyLevelAndTimestampsBetweenAndUserId(@Param("start") Instant start, @Param("end") Instant end, @Param("userId") Long userId);
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
+            "FROM TailEntity t WHERE t.resolvedTimestamp IS NOT NULL AND t.timestamp >= :daysAgo AND t.userId = :userId")
+    List<TailTimestampAndResolvedTimestamp> findAllByTimestampAfterAndResolvedTimestampIsNotNullAndUserId(@Param("daysAgo") Instant daysAgo, @Param("userId") Long userId);
+
+    // Methods for filtering by OrganizationIdIn
+    @Query("SELECT COUNT(t) FROM TailEntity t JOIN t.organization o WHERE t.timestamp BETWEEN :startOfDay AND :endOfDay AND o.id IN :organizationIds")
+    long countByTimestampBetweenAndOrganizationIdIn(@Param("startOfDay") Instant startOfDay, @Param("endOfDay") Instant endOfDay, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT t FROM TailEntity t JOIN t.organization o WHERE t.timestamp BETWEEN :startOfDay AND :endOfDay AND o.id IN :organizationIds")
+    List<TailEntity> findByTimestampBetweenAndOrganizationIdIn(@Param("startOfDay") Instant startOfDay, @Param("endOfDay") Instant endOfDay, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT t FROM TailEntity t JOIN t.organization o WHERE t.status.name = :statusName AND o.id IN :organizationIds")
+    List<TailEntity> findAllByStatusNameAndOrganizationIdIn(@Param("statusName") String statusName, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT COUNT(t) FROM TailEntity t JOIN t.organization o WHERE t.status.name = :statusName AND o.id IN :organizationIds")
+    long countByStatusNameAndOrganizationIdIn(@Param("statusName") String statusName, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT t FROM TailEntity t JOIN t.organization o WHERE t.status.name <> :statusName AND o.id IN :organizationIds")
+    List<TailEntity> findAllByStatusNameNotAndOrganizationIdIn(@Param("statusName") String statusName, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT COUNT(t) FROM TailEntity t JOIN t.organization o WHERE t.status.name <> :statusName AND o.id IN :organizationIds")
+    long countByStatusNameNotAndOrganizationIdIn(@Param("statusName") String statusName, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
+            "FROM TailEntity t JOIN t.organization o WHERE t.resolvedTimestamp IS NOT NULL AND o.id IN :organizationIds")
+    List<TailTimestampAndResolvedTimestamp> findOnlyTimestampAndResolvedTimestampIsNotNullAndOrganizationIdIn(@Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT t.timestamp FROM TailEntity t JOIN t.organization o WHERE t.timestamp BETWEEN :start AND :end AND o.id IN :organizationIds ORDER BY t.timestamp ASC")
+    List<Instant> findOnlyTimestampsBetweenAndOrganizationIdIn(@Param("start") Instant start, @Param("end") Instant end, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailLevelAndTimestamp(t.timestamp, t.level) " +
+            "FROM TailEntity t JOIN t.organization o WHERE t.timestamp BETWEEN :start AND :end AND o.id IN :organizationIds ORDER BY t.timestamp ASC")
+    List<TailLevelAndTimestamp> findOnlyLevelAndTimestampsBetweenAndOrganizationIdIn(@Param("start") Instant start, @Param("end") Instant end, @Param("organizationIds") List<Long> organizationIds);
+
+    @Query("SELECT new com.n1netails.n1netails.api.model.dto.TailTimestampAndResolvedTimestamp(t.timestamp, t.resolvedTimestamp) " +
+            "FROM TailEntity t JOIN t.organization o WHERE t.resolvedTimestamp IS NOT NULL AND t.timestamp >= :daysAgo AND o.id IN :organizationIds")
+    List<TailTimestampAndResolvedTimestamp> findAllByTimestampAfterAndResolvedTimestampIsNotNullAndOrganizationIdIn(@Param("daysAgo") Instant daysAgo, @Param("organizationIds") List<Long> organizationIds);
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailMetricsService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailMetricsService.java
@@ -6,20 +6,20 @@ import java.util.List;
 
 public interface TailMetricsService {
 
-    List<TailResponse> tailAlertsToday(String timezone);
-    long countAlertsToday(String timezone);
+    List<TailResponse> tailAlertsToday(String timezone, Long userId, List<Long> organizationIds);
+    long countAlertsToday(String timezone, Long userId, List<Long> organizationIds);
 
-    List<TailResponse> tailAlertsResolved();
-    long countAlertsResolved();
+    List<TailResponse> tailAlertsResolved(Long userId, List<Long> organizationIds);
+    long countAlertsResolved(Long userId, List<Long> organizationIds);
 
-    List<TailResponse> tailAlertsNotResolved();
-    long countAlertsNotResolved();
+    List<TailResponse> tailAlertsNotResolved(Long userId, List<Long> organizationIds);
+    long countAlertsNotResolved(Long userId, List<Long> organizationIds);
 
-    long tailAlertsMTTR();
+    long tailAlertsMTTR(Long userId, List<Long> organizationIds);
 
-    TailAlertsPerHourResponse getTailAlertsPerHour(String timezone);
+    TailAlertsPerHourResponse getTailAlertsPerHour(String timezone, Long userId, List<Long> organizationIds);
 
-    TailMonthlySummaryResponse getTailMonthlySummary(String timezone);
+    TailMonthlySummaryResponse getTailMonthlySummary(String timezone, Long userId, List<Long> organizationIds);
 
-    TailDatasetMttrResponse getTailMTTRLast7Days();
+    TailDatasetMttrResponse getTailMTTRLast7Days(Long userId, List<Long> organizationIds);
 }


### PR DESCRIPTION
I've moved tail metrics-specific queries from TailRepository to a new TailMetricsRepository.

I also modified TailMetricsController and TailMetricsService to restrict your access to tail metrics:
- You can only see tails related to organizations you are part of.
- If you are part of the 'n1netails' organization, you can only view your own tails.

This change implements the specified authorization rules for tail metrics data.