### PR TITLE
feat: Add NoteController with CRUD operations and authorization

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/NoteController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/NoteController.java
@@ -1,0 +1,213 @@
+package com.n1netails.n1netails.api.controller;
+
+import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.dto.Note;
+import com.n1netails.n1netails.api.model.request.NotePageRequest;
+import com.n1netails.n1netails.api.service.AuthorizationService;
+import com.n1netails.n1netails.api.service.NoteService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.n1netails.n1netails.api.exception.type.*;
+import com.n1netails.n1netails.api.model.response.HttpErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.HttpStatus;
+
+
+import java.util.List;
+
+import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
+
+@Slf4j
+@RequiredArgsConstructor
+@Tag(name = "Note Controller", description = "Operations related to Notes")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping(path = {"/ninetails/note"}, produces = APPLICATION_JSON)
+public class NoteController {
+
+    private final NoteService noteService;
+    private final AuthorizationService authorizationService;
+
+    @Operation(summary = "Create a new note for a tail", responses = {
+            @ApiResponse(responseCode = "201", description = "Note created successfully",
+                    content = @Content(schema = @Schema(implementation = Note.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized to create note for this tail",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User not assigned to tail or lacking permissions",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Tail or User not found",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "N1 note already exists for this tail",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<Note> createNote(@RequestHeader("Authorization") String authorizationHeader,
+                                           @RequestBody Note noteRequest)
+            throws UserNotFoundException, TailNotFoundException, UnauthorizedException, N1NoteAlreadyExistsException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.info("User {} attempting to create note for tail {}", currentUser.getUsername(), noteRequest.getTailId());
+
+        if (noteRequest.getTailId() == null) {
+            // Or handle with a specific validation error/exception
+            log.warn("Tail ID is null in create note request by user {}", currentUser.getUsername());
+            throw new IllegalArgumentException("Tail ID cannot be null when creating a note.");
+        }
+
+        // Authorization Check: Only users assigned to a tail (or org admins/super admins) can create notes for that tail.
+        if (!authorizationService.isUserAssignedToTail(currentUser, noteRequest.getTailId())) {
+            log.warn("User {} is not authorized to create a note for tail {}", currentUser.getUsername(), noteRequest.getTailId());
+            throw new UnauthorizedException("User is not authorized to create notes for this tail.");
+        }
+
+        // Populate user details from the authenticated principal, not the request body for security.
+        noteRequest.setUserId(currentUser.getId());
+        noteRequest.setUsername(currentUser.getUsername());
+        // Assuming organizationId might also come from the tail or should be verified.
+        // For now, if it's part of the Note DTO and set by client, ensure it's consistent or derived server-side.
+        // Let NoteService handle setting/validating organizationId based on tailId if necessary.
+
+        Note createdNote = noteService.add(noteRequest);
+        log.info("Note created with ID {} for tail {} by user {}", createdNote.getId(), createdNote.getTailId(), currentUser.getUsername());
+        return new ResponseEntity<>(createdNote, HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "Get a note by its ID", responses = {
+            @ApiResponse(responseCode = "200", description = "Note found",
+                    content = @Content(schema = @Schema(implementation = Note.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this note's tail",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Note not found",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class)))
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<Note> getNoteById(@RequestHeader("Authorization") String authorizationHeader,
+                                            @PathVariable Long id)
+            throws UserNotFoundException, NoteNotFoundException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.debug("User {} attempting to fetch note with ID {}", currentUser.getUsername(), id);
+
+        Note note = noteService.getById(id);
+
+        // Authorization Check
+        if (!authorizationService.isUserAssignedToTail(currentUser, note.getTailId())) {
+            log.warn("User {} is not authorized to access note {} for tail {}", currentUser.getUsername(), id, note.getTailId());
+            throw new UnauthorizedException("User is not authorized to access this note.");
+        }
+        log.info("User {} fetched note with ID {}", currentUser.getUsername(), id);
+        return ResponseEntity.ok(note);
+    }
+
+    @Operation(summary = "Get all notes for a specific tail", responses = {
+            @ApiResponse(responseCode = "200", description = "List of notes for the tail"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this tail"),
+            @ApiResponse(responseCode = "404", description = "Tail not found")
+    })
+    @GetMapping("/tail/{tailId}")
+    public ResponseEntity<List<Note>> getAllNotesByTailId(@RequestHeader("Authorization") String authorizationHeader,
+                                                         @PathVariable Long tailId)
+            throws UserNotFoundException, TailNotFoundException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.debug("User {} attempting to fetch all notes for tail {}", currentUser.getUsername(), tailId);
+
+        // Authorization Check
+        if (!authorizationService.isUserAssignedToTail(currentUser, tailId)) {
+            log.warn("User {} is not authorized to access notes for tail {}", currentUser.getUsername(), tailId);
+            throw new UnauthorizedException("User is not authorized to access notes for this tail.");
+        }
+
+        List<Note> notes = noteService.getAllByTailId(tailId);
+        log.info("User {} fetched {} notes for tail {}", currentUser.getUsername(), notes.size(), tailId);
+        return ResponseEntity.ok(notes);
+    }
+
+    @Operation(summary = "Get the last 9 notes for a specific tail", responses = {
+            @ApiResponse(responseCode = "200", description = "List of last 9 notes"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this tail"),
+            @ApiResponse(responseCode = "404", description = "Tail not found")
+    })
+    @GetMapping("/tail/{tailId}/latest")
+    public ResponseEntity<List<Note>> getLast9NotesByTailId(@RequestHeader("Authorization") String authorizationHeader,
+                                                             @PathVariable Long tailId)
+            throws UserNotFoundException, TailNotFoundException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.debug("User {} attempting to fetch latest notes for tail {}", currentUser.getUsername(), tailId);
+
+        // Authorization Check
+        if (!authorizationService.isUserAssignedToTail(currentUser, tailId)) {
+            log.warn("User {} is not authorized to access notes for tail {}", currentUser.getUsername(), tailId);
+            throw new UnauthorizedException("User is not authorized to access notes for this tail.");
+        }
+
+        List<Note> notes = noteService.getLast9NotesByTailId(tailId);
+        log.info("User {} fetched {} latest notes for tail {}", currentUser.getUsername(), notes.size(), tailId);
+        return ResponseEntity.ok(notes);
+    }
+
+    @Operation(summary = "Get notes for a specific tail with pagination", responses = {
+            @ApiResponse(responseCode = "200", description = "Page of notes"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this tail")
+    })
+    @PostMapping("/tail/page")
+    public ResponseEntity<Page<Note>> getNotesByTailIdPaginated(@RequestHeader("Authorization") String authorizationHeader,
+                                                               @RequestBody NotePageRequest request)
+            throws UserNotFoundException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.debug("User {} attempting to fetch paginated notes for tail {}", currentUser.getUsername(), request.getTailId());
+
+        if (request.getTailId() == null) {
+             log.warn("Tail ID is null in note page request by user {}", currentUser.getUsername());
+            throw new IllegalArgumentException("Tail ID cannot be null in NotePageRequest.");
+        }
+
+        // Authorization Check
+        if (!authorizationService.isUserAssignedToTail(currentUser, request.getTailId())) {
+            log.warn("User {} is not authorized to access notes for tail {}", currentUser.getUsername(), request.getTailId());
+            throw new UnauthorizedException("User is not authorized to access notes for this tail.");
+        }
+
+        Page<Note> notesPage = noteService.getNotesByTailId(request);
+        log.info("User {} fetched page {} of notes for tail {}", currentUser.getUsername(), request.getPage(), request.getTailId());
+        return ResponseEntity.ok(notesPage);
+    }
+
+    @Operation(summary = "Get the N1 note for a specific tail", responses = {
+            @ApiResponse(responseCode = "200", description = "N1 Note found",
+                    content = @Content(schema = @Schema(implementation = Note.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User not authorized for this tail"),
+            @ApiResponse(responseCode = "404", description = "N1 Note or Tail not found",
+                    content = @Content(schema = @Schema(implementation = HttpErrorResponse.class)))
+    })
+    @GetMapping("/tail/{tailId}/isN1")
+    public ResponseEntity<Note> getN1NoteByTailId(@RequestHeader("Authorization") String authorizationHeader,
+                                                 @PathVariable Long tailId)
+            throws UserNotFoundException, NoteNotFoundException, UnauthorizedException, TailNotFoundException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        log.debug("User {} attempting to fetch N1 note for tail {}", currentUser.getUsername(), tailId);
+
+        // Authorization Check
+        if (!authorizationService.isUserAssignedToTail(currentUser, tailId)) {
+            log.warn("User {} is not authorized to access N1 note for tail {}", currentUser.getUsername(), tailId);
+            throw new UnauthorizedException("User is not authorized to access the N1 note for this tail.");
+        }
+        // NoteService.getIsN1ByTailId might throw NoteNotFoundException if no N1 note exists or TailNotFoundException implicitly.
+        Note n1Note = noteService.getIsN1ByTailId(tailId);
+        log.info("User {} fetched N1 note with ID {} for tail {}", currentUser.getUsername(), n1Note.getId(), tailId);
+        return ResponseEntity.ok(n1Note);
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/NoteController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/NoteController.java
@@ -57,24 +57,13 @@ public class NoteController {
         UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         log.info("User {} attempting to create note for tail {}", currentUser.getUsername(), noteRequest.getTailId());
 
-        if (noteRequest.getTailId() == null) {
-            // Or handle with a specific validation error/exception
-            log.warn("Tail ID is null in create note request by user {}", currentUser.getUsername());
-            throw new IllegalArgumentException("Tail ID cannot be null when creating a note.");
-        }
-
-        // Authorization Check: Only users assigned to a tail (or org admins/super admins) can create notes for that tail.
         if (!authorizationService.isUserAssignedToTail(currentUser, noteRequest.getTailId())) {
             log.warn("User {} is not authorized to create a note for tail {}", currentUser.getUsername(), noteRequest.getTailId());
             throw new UnauthorizedException("User is not authorized to create notes for this tail.");
         }
 
-        // Populate user details from the authenticated principal, not the request body for security.
         noteRequest.setUserId(currentUser.getId());
         noteRequest.setUsername(currentUser.getUsername());
-        // Assuming organizationId might also come from the tail or should be verified.
-        // For now, if it's part of the Note DTO and set by client, ensure it's consistent or derived server-side.
-        // Let NoteService handle setting/validating organizationId based on tailId if necessary.
 
         Note createdNote = noteService.add(noteRequest);
         log.info("Note created with ID {} for tail {} by user {}", createdNote.getId(), createdNote.getTailId(), currentUser.getUsername());
@@ -100,7 +89,6 @@ public class NoteController {
 
         Note note = noteService.getById(id);
 
-        // Authorization Check
         if (!authorizationService.isUserAssignedToTail(currentUser, note.getTailId())) {
             log.warn("User {} is not authorized to access note {} for tail {}", currentUser.getUsername(), id, note.getTailId());
             throw new UnauthorizedException("User is not authorized to access this note.");
@@ -122,7 +110,6 @@ public class NoteController {
         UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         log.debug("User {} attempting to fetch all notes for tail {}", currentUser.getUsername(), tailId);
 
-        // Authorization Check
         if (!authorizationService.isUserAssignedToTail(currentUser, tailId)) {
             log.warn("User {} is not authorized to access notes for tail {}", currentUser.getUsername(), tailId);
             throw new UnauthorizedException("User is not authorized to access notes for this tail.");
@@ -146,7 +133,6 @@ public class NoteController {
         UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         log.debug("User {} attempting to fetch latest notes for tail {}", currentUser.getUsername(), tailId);
 
-        // Authorization Check
         if (!authorizationService.isUserAssignedToTail(currentUser, tailId)) {
             log.warn("User {} is not authorized to access notes for tail {}", currentUser.getUsername(), tailId);
             throw new UnauthorizedException("User is not authorized to access notes for this tail.");
@@ -174,7 +160,6 @@ public class NoteController {
             throw new IllegalArgumentException("Tail ID cannot be null in NotePageRequest.");
         }
 
-        // Authorization Check
         if (!authorizationService.isUserAssignedToTail(currentUser, request.getTailId())) {
             log.warn("User {} is not authorized to access notes for tail {}", currentUser.getUsername(), request.getTailId());
             throw new UnauthorizedException("User is not authorized to access notes for this tail.");
@@ -200,12 +185,11 @@ public class NoteController {
         UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         log.debug("User {} attempting to fetch N1 note for tail {}", currentUser.getUsername(), tailId);
 
-        // Authorization Check
         if (!authorizationService.isUserAssignedToTail(currentUser, tailId)) {
             log.warn("User {} is not authorized to access N1 note for tail {}", currentUser.getUsername(), tailId);
             throw new UnauthorizedException("User is not authorized to access the N1 note for this tail.");
         }
-        // NoteService.getIsN1ByTailId might throw NoteNotFoundException if no N1 note exists or TailNotFoundException implicitly.
+
         Note n1Note = noteService.getIsN1ByTailId(tailId);
         log.info("User {} fetched N1 note with ID {} for tail {}", currentUser.getUsername(), n1Note.getId(), tailId);
         return ResponseEntity.ok(n1Note);

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/ExceptionController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/ExceptionController.java
@@ -66,7 +66,10 @@ public class ExceptionController implements ErrorController {
      * @param exception conflict exception
      * @return http error response
      */
-    @ExceptionHandler(EmailExistException.class)
+    @ExceptionHandler({
+            EmailExistException.class,
+            N1NoteAlreadyExistsException.class
+    })
     public ResponseEntity<HttpErrorResponse> conflictException(Exception exception) {
         log.error(exception.getMessage());
         return createHttpResponse(CONFLICT, exception.getMessage());

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/AuthorizationService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/AuthorizationService.java
@@ -19,4 +19,6 @@ public interface AuthorizationService {
     boolean isSelf(UserPrincipal principal, Long userIdToCheck);
 
     boolean isOwnerOrOrganizationAdmin(UserPrincipal principal, Long ownerUserId, Long organizationId);
+
+    boolean isUserAssignedToTail(UserPrincipal principal, Long tailId);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/AuthorizationServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/AuthorizationServiceImpl.java
@@ -114,7 +114,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         TailEntity tail = tailRepository.findById(tailId).orElse(null);
         if (tail == null) {
             log.warn("Tail not found for ID: {} during authorization check", tailId);
-            return false; // Or throw TailNotFoundException if preferred, but for auth check, false is safer.
+            return false;
         }
 
         // Check if user is directly assigned

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/AuthorizationServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/AuthorizationServiceImpl.java
@@ -3,7 +3,9 @@ package com.n1netails.n1netails.api.service.impl;
 import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
 import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
+import com.n1netails.n1netails.api.model.entity.TailEntity;
 import com.n1netails.n1netails.api.model.entity.UsersEntity;
+import com.n1netails.n1netails.api.repository.TailRepository;
 import com.n1netails.n1netails.api.repository.UserRepository;
 import com.n1netails.n1netails.api.service.AuthorizationService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
 
     private final UserRepository userRepository;
     private final JwtDecoder jwtDecoder;
+    private final TailRepository tailRepository;
 
     @Override
     public UserPrincipal getCurrentUserPrincipal(String authorizationHeader) throws UserNotFoundException {
@@ -97,6 +100,42 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             return true;
         }
         log.info("User {} is neither owner (ID: {}) nor admin for organization {}", principal.getUsername(), ownerUserId, organizationId);
+        return false;
+    }
+
+    @Override
+    public boolean isUserAssignedToTail(UserPrincipal principal, Long tailId) {
+        log.debug("Checking if user {} is assigned to tail {}", principal.getUsername(), tailId);
+        if (principal == null || tailId == null) {
+            return false;
+        }
+        // Super admins and organization admins of the tail's organization can also access notes
+        // So, first fetch the tail to check its organization and assigned user.
+        TailEntity tail = tailRepository.findById(tailId).orElse(null);
+        if (tail == null) {
+            log.warn("Tail not found for ID: {} during authorization check", tailId);
+            return false; // Or throw TailNotFoundException if preferred, but for auth check, false is safer.
+        }
+
+        // Check if user is directly assigned
+        if (principal.getId().equals(tail.getAssignedUserId())) {
+            log.info("User {} is directly assigned to tail {}", principal.getUsername(), tailId);
+            return true;
+        }
+
+        // Check if user is an admin of the organization the tail belongs to
+        if (tail.getOrganization() != null && isOrganizationAdmin(principal, tail.getOrganization().getId())) {
+            log.info("User {} is an admin of the organization {} for tail {}", principal.getUsername(), tail.getOrganization().getId(), tailId);
+            return true;
+        }
+
+        // Check if user is super admin
+        if(isSuperAdmin(principal)){
+            log.info("User {} is Super Admin and can access tail {}", principal.getUsername(), tailId);
+            return true;
+        }
+
+        log.info("User {} is not authorized for tail {}", principal.getUsername(), tailId);
         return false;
     }
 }


### PR DESCRIPTION
Implemented NoteController to manage notes associated with tails.

Key features:
- CRUD operations for notes:
  - POST /ninetails/note (Create a new note)
  - GET /ninetails/note/{id} (Get note by ID)
  - GET /ninetails/note/tail/{tailId} (Get all notes for a tail)
  - GET /ninetails/note/tail/{tailId}/latest (Get latest 9 notes for a tail)
  - POST /ninetails/note/tail/page (Get notes for a tail with pagination)
  - GET /ninetails/note/tail/{tailId}/isN1 (Get N1 note for a tail)

- Authorization:
  - Enhanced AuthorizationService with `isUserAssignedToTail` method.
  - Note creation is restricted to users assigned to the tail, organization admins of the tail's organization, or super admins.
  - Read access to notes is similarly restricted based on tail authorization.
  - User ID and username for new notes are set from the authenticated principal.

- Swagger API documentation added for all new endpoints.
- Existing DTOs (Note.java, NotePageRequest.java) were utilized.