### PR TITLE
feat: Implement passkey (WebAuthn) authentication

### DIFF
--- a/n1netails-api/pom.xml
+++ b/n1netails-api/pom.xml
@@ -90,6 +90,23 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Yubico WebAuthn -->
+		<dependency>
+			<groupId>com.yubico</groupId>
+			<artifactId>webauthn-server-core</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.yubico</groupId>
+			<artifactId>webauthn-server-attestation</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.yubico</groupId>
+			<artifactId>yubico-util</artifactId>
+			<version>2.7.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/config/WebAuthnConfig.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/config/WebAuthnConfig.java
@@ -1,0 +1,83 @@
+package com.n1netails.n1netails.api.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.n1netails.n1netails.api.repository.PasskeyCredentialRepository;
+import com.n1netails.n1netails.api.service.AppCredentialRepository; // This will be an adapter class
+import com.yubico.webauthn.CredentialRepository;
+import com.yubico.webauthn.RelyingParty;
+import com.yubico.webauthn.data.RelyingPartyIdentity;
+import com.yubico.webauthn.extension.largeblob.LargeBlobServerExtension; // Corrected import
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays; // Added import
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@Configuration
+public class WebAuthnConfig {
+
+    @Value("${webauthn.relying-party-id}")
+    private String relyingPartyId;
+
+    @Value("${webauthn.relying-party-name}")
+    private String relyingPartyName;
+
+    @Value("${webauthn.relying-party-origins}")
+    private Set<String> relyingPartyOrigins;
+
+    // This is an adapter between Yubico's CredentialRepository and our PasskeyCredentialRepository
+    @Bean
+    public CredentialRepository yubicoCredentialRepository(PasskeyCredentialRepository passkeyCredentialRepository, ObjectMapper objectMapper) {
+        return new AppCredentialRepository(passkeyCredentialRepository, objectMapper);
+    }
+
+    @Bean
+    public RelyingParty relyingParty(CredentialRepository credentialRepository,
+                                     @Value("${server.ssl.enabled:false}") boolean sslEnabled,
+                                     @Value("${server.port}") int port,
+                                     @Value("${server.address:localhost}") String address) {
+        RelyingPartyIdentity rpIdentity = RelyingPartyIdentity.builder()
+                .id(relyingPartyId)
+                .name(relyingPartyName)
+                .build();
+
+        // If origins are not explicitly set, try to derive from server config
+        Set<String> effectiveOrigins = new HashSet<>(this.relyingPartyOrigins);
+        if (effectiveOrigins.isEmpty()) {
+            String protocol = sslEnabled ? "https://" : "http://";
+            String origin = protocol + address + ":" + port;
+            effectiveOrigins.add(origin);
+            // Add common localhost variations for development if RP ID is localhost
+            if ("localhost".equalsIgnoreCase(relyingPartyId) && "localhost".equalsIgnoreCase(address)) {
+                 effectiveOrigins.add("http://localhost:" + port); // Already added
+                 effectiveOrigins.add("http://127.0.0.1:" + port);
+            }
+        }
+
+        // Configure allowable AAGUIDs (optional, for restricting to specific authenticators)
+        // Set<ByteArray> allowedAaguids = new HashSet<>();
+        // allowedAaguids.add(AAGUID.fromHex("c5defc69-2058-4390-9b97-0abb90800a0d")); // Example YubiKey 5 AAGUID
+
+        return RelyingParty.builder()
+                .identity(rpIdentity)
+                .credentialRepository(credentialRepository)
+                .origins(effectiveOrigins)
+                // .allowUntrustedAttestation(true) // Useful for development, but be cautious in production
+                // .attestationTrustSource(new TrustStoreAttestationTrustSource(trustStore)) // For production with MDS
+                // .allowedAaguids(allowedAaguids) // Optional: restrict allowed authenticators by AAGUID
+                .validateSignatureCounter(true)
+                .allowOriginPort(true) // Allow origins with port numbers
+                .allowOriginSubdomain(false) // Set to true if you want to allow subdomains
+                .extensions(Arrays.asList( // Use Arrays.asList
+                    new LargeBlobServerExtension() // Corrected extension
+                ))
+                .build();
+    }
+
+    // We need an ObjectMapper for serializing/deserializing Yubico objects if we store them as JSON
+    // Spring Boot provides one by default, but we can customize it if needed.
+    // For now, relying on the default Spring Boot ObjectMapper.
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/constant/ControllerConstant.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/constant/ControllerConstant.java
@@ -4,5 +4,9 @@ public class ControllerConstant {
 
     public static final String APPLICATION_JSON = "application/json";
 
+    public static final String API_BASE_V1_MAPPING = "/api/v1";
+    public static final String API_PASSKEY_V1_MAPPING = API_BASE_V1_MAPPING + "/passkey";
+
+
     private ControllerConstant() {}
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasskeyController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasskeyController.java
@@ -1,0 +1,62 @@
+package com.n1netails.n1netails.api.controller;
+
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyLoginFinishRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyLoginStartRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyRegistrationFinishRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyRegistrationStartRequest;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyAuthenticationResponse;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyLoginStartResponse;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyRegistrationStartResponse;
+import com.n1netails.n1netails.api.service.PasskeyService; // Uncommented
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.n1netails.n1netails.api.constant.ControllerConstant.API_PASSKEY_V1_MAPPING;
+
+@Slf4j
+@RestController
+@RequestMapping(API_PASSKEY_V1_MAPPING)
+@RequiredArgsConstructor
+// @CrossOrigin(origins = "*", maxAge = 3600) // Consider if needed, or use global config
+public class PasskeyController {
+
+    private final PasskeyService passkeyService; // Uncommented and enabled
+
+    @PostMapping("/register/start")
+    public ResponseEntity<PasskeyRegistrationStartResponse> startRegistration(@Valid @RequestBody PasskeyRegistrationStartRequest request) {
+        log.info("Received passkey registration start request for username: {}", request.getUsername());
+        PasskeyRegistrationStartResponse response = passkeyService.startRegistration(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/register/finish")
+    public ResponseEntity<Void> finishRegistration(@Valid @RequestBody PasskeyRegistrationFinishRequest request) {
+        log.info("Received passkey registration finish request with ID: {}", request.getRegistrationId());
+        passkeyService.finishRegistration(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/login/start")
+    public ResponseEntity<PasskeyLoginStartResponse> startLogin(@RequestBody(required = false) PasskeyLoginStartRequest request) {
+        // Username might be null for discoverable credentials
+        log.info("Received passkey login start request for username: {}", request != null ? request.getUsername() : "N/A (discoverable)");
+        PasskeyLoginStartResponse response = passkeyService.startLogin(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login/finish")
+    public ResponseEntity<PasskeyAuthenticationResponse> finishLogin(@Valid @RequestBody PasskeyLoginFinishRequest request) {
+        log.info("Received passkey login finish request with ID: {}", request.getAssertionId());
+        PasskeyAuthenticationResponse response = passkeyService.finishLogin(request);
+        // Similar to UserController, we might want to return the token in a header.
+        // However, PasskeyAuthenticationResponse already includes the token in its body.
+        // For consistency, let's also add it to the header.
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Jwt-Token", response.getToken());
+        return new ResponseEntity<>(response, headers, HttpStatus.OK);
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/PasskeyCredentialEntity.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/PasskeyCredentialEntity.java
@@ -1,0 +1,74 @@
+package com.n1netails.n1netails.api.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp; // Or use @PreUpdate for lastUsedAt
+
+import java.time.OffsetDateTime; // Using OffsetDateTime for timezone awareness
+
+@Entity
+@Table(name = "passkey_credentials", indexes = {
+    @Index(name = "idx_passkey_credentials_user_id", columnList = "user_id"),
+    @Index(name = "idx_passkey_credentials_user_handle", columnList = "userHandle")
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasskeyCredentialEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UsersEntity user;
+
+    @Column(name = "external_id", nullable = false, unique = true, length = 2048)
+    private String externalId; // Base64URL representation of Credential ID
+
+    @Column(name = "public_key_cose", nullable = false, length = 2048)
+    private String publicKeyCose; // Base64URL representation of COSE public key
+
+    @Column(name = "count", nullable = false)
+    private Long count; // Signature counter
+
+    @Column(name = "aaguid", length = 36)
+    private String aaguid; // Authenticator Attestation Globally Unique Identifier
+
+    @Column(name = "user_handle", nullable = false) // User handle used during registration
+    private String userHandle;
+
+    @Column(name = "credential_type", length = 255)
+    private String credentialType; // e.g., "public-key"
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    // This should be updated on each successful authentication
+    @Column(name = "last_used_at", nullable = false)
+    private OffsetDateTime lastUsedAt;
+
+    @Column(name = "user_agent", length = 512)
+    private String userAgent; // User agent of the client that registered the key
+
+    @Column(name = "friendly_name", length = 255)
+    private String friendlyName; // Optional: a name given by the user for the passkey
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now();
+        lastUsedAt = OffsetDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        // lastUsedAt will be updated manually upon successful login
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/PasskeyRegistrationRequestEntity.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/PasskeyRegistrationRequestEntity.java
@@ -1,0 +1,44 @@
+package com.n1netails.n1netails.api.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "passkey_registration_requests", indexes = {
+    @Index(name = "idx_passkey_reg_requests_created_at", columnList = "createdAt")
+})
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasskeyRegistrationRequestEntity {
+
+    @Id
+    @Column(name = "request_id", length = 255) // Stores the challenge
+    private String requestId;
+
+    @Column(name = "user_id") // Can be null if user is not yet fully identified
+    private Long userId;
+
+    @Column(name = "username")
+    private String username; // Store username for linking back if userId is not available yet
+
+    @Lob // For potentially large JSON string
+    @Column(name = "registration_options", nullable = false, columnDefinition = "TEXT")
+    private String registrationOptions; // JSON serialized PublicKeyCredentialCreationOptions
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now();
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyLoginFinishRequest.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyLoginFinishRequest.java
@@ -1,0 +1,13 @@
+package com.n1netails.n1netails.api.model.request.passkey;
+
+import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
+
+@Data
+public class PasskeyLoginFinishRequest {
+    @NotBlank(message = "Assertion ID cannot be blank")
+    private String assertionId; // Corresponds to the challenge / request_id
+
+    @NotBlank(message = "Credential data cannot be blank")
+    private String credential; // JSON string of PublicKeyCredential from navigator.credentials.get()
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyLoginStartRequest.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyLoginStartRequest.java
@@ -1,0 +1,9 @@
+package com.n1netails.n1netails.api.model.request.passkey;
+
+import lombok.Data;
+
+@Data
+public class PasskeyLoginStartRequest {
+    // Username might be optional if relying on discoverable credentials (passkeys)
+    private String username;
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyRegistrationFinishRequest.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyRegistrationFinishRequest.java
@@ -1,0 +1,13 @@
+package com.n1netails.n1netails.api.model.request.passkey;
+
+import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
+
+@Data
+public class PasskeyRegistrationFinishRequest {
+    @NotBlank(message = "Registration ID cannot be blank")
+    private String registrationId; // Corresponds to the challenge / request_id
+
+    @NotBlank(message = "Credential data cannot be blank")
+    private String credential; // JSON string of PublicKeyCredential from navigator.credentials.create()
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyRegistrationStartRequest.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/passkey/PasskeyRegistrationStartRequest.java
@@ -1,0 +1,11 @@
+package com.n1netails.n1netails.api.model.request.passkey;
+
+import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
+
+@Data
+public class PasskeyRegistrationStartRequest {
+    @NotBlank(message = "Username cannot be blank")
+    private String username;
+    private String displayName; // Optional: user's display name for the passkey
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/passkey/PasskeyAuthenticationResponse.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/passkey/PasskeyAuthenticationResponse.java
@@ -1,0 +1,14 @@
+package com.n1netails.n1netails.api.model.response.passkey;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasskeyAuthenticationResponse {
+    private String token;
+    private String username;
+    private String message;
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/passkey/PasskeyLoginStartResponse.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/passkey/PasskeyLoginStartResponse.java
@@ -1,0 +1,13 @@
+package com.n1netails.n1netails.api.model.response.passkey;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasskeyLoginStartResponse {
+    private String assertionId; // The challenge, to be stored by the frontend and sent back
+    private String options; // JSON string of PublicKeyCredentialRequestOptions
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/passkey/PasskeyRegistrationStartResponse.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/passkey/PasskeyRegistrationStartResponse.java
@@ -1,0 +1,13 @@
+package com.n1netails.n1netails.api.model.response.passkey;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasskeyRegistrationStartResponse {
+    private String registrationId; // The challenge, to be stored by the frontend and sent back
+    private String options; // JSON string of PublicKeyCredentialCreationOptions
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/PasskeyCredentialRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/PasskeyCredentialRepository.java
@@ -1,0 +1,26 @@
+package com.n1netails.n1netails.api.repository;
+
+import com.n1netails.n1netails.api.model.entity.PasskeyCredentialEntity;
+import com.n1netails.n1netails.api.model.entity.UsersEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PasskeyCredentialRepository extends JpaRepository<PasskeyCredentialEntity, Long> {
+
+    Optional<PasskeyCredentialEntity> findByExternalId(String externalId);
+
+    List<PasskeyCredentialEntity> findByUser(UsersEntity user);
+
+    List<PasskeyCredentialEntity> findByUserHandle(String userHandle);
+
+    boolean existsByUserAndFriendlyName(UsersEntity user, String friendlyName);
+
+    // Added for AppCredentialRepository
+    List<PasskeyCredentialEntity> findByUser_Email(String email);
+
+    Optional<PasskeyCredentialEntity> findByExternalIdAndUserHandle(String externalId, String userHandle);
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/PasskeyRegistrationRequestRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/PasskeyRegistrationRequestRepository.java
@@ -1,0 +1,16 @@
+package com.n1netails.n1netails.api.repository;
+
+import com.n1netails.n1netails.api.model.entity.PasskeyRegistrationRequestEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+@Repository
+public interface PasskeyRegistrationRequestRepository extends JpaRepository<PasskeyRegistrationRequestEntity, String> {
+
+    Optional<PasskeyRegistrationRequestEntity> findByRequestId(String requestId);
+
+    void deleteAllByCreatedAtBefore(OffsetDateTime expiryTime);
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/AppCredentialRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/AppCredentialRepository.java
@@ -1,0 +1,105 @@
+package com.n1netails.n1netails.api.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.n1netails.n1netails.api.model.entity.PasskeyCredentialEntity;
+import com.n1netails.n1netails.api.model.entity.UsersEntity;
+import com.n1netails.n1netails.api.repository.PasskeyCredentialRepository;
+import com.yubico.webauthn.CredentialRepository;
+import com.yubico.webauthn.RegisteredCredential;
+import com.yubico.webauthn.data.ByteArray;
+import com.yubico.webauthn.data.PublicKeyCredentialDescriptor;
+import com.yubico.webauthn.data.UserIdentity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service; // Should be a component managed by Spring for injection
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor // Not a @Service itself, but instantiated in WebAuthnConfig
+public class AppCredentialRepository implements CredentialRepository {
+
+    private final PasskeyCredentialRepository passkeyCredentialRepository;
+    private final ObjectMapper objectMapper; // For potential JSON conversion if needed for extra fields, not directly used by Yubico interface methods
+
+    @Override
+    public Set<PublicKeyCredentialDescriptor> getCredentialIdsForUsername(String username) {
+        // This method is a bit tricky as our PasskeyCredentialEntity is linked to UsersEntity by ID, not directly by username string
+        // And Yubico's CredentialRepository interface uses username string.
+        // For now, this implies that the username in Yubico's context IS the userHandle or we need another way to link them.
+        // Let's assume for now that userHandle is what Yubico expects as "username" in this context for lookup.
+        // This might need adjustment based on how UserIdentity.name is populated during registration.
+        // If UserIdentity.name is the user's primary email/login username, we'd need to fetch the user by that, then their credentials.
+        // For simplicity, let's assume the 'username' parameter here refers to the userHandle.
+        log.debug("Getting credential IDs for userHandle: {}", username);
+        return passkeyCredentialRepository.findByUserHandle(username).stream()
+                .map(cred -> PublicKeyCredentialDescriptor.builder()
+                        .id(ByteArray.fromBase64Url(cred.getExternalId()))
+                        .build())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Optional<ByteArray> getUserHandleForUsername(String username) {
+        // This method is called by Yubico lib to get a persistent, non-personally identifiable user handle.
+        // We store userHandle in PasskeyCredentialEntity. If the 'username' parameter is the actual login username,
+        // we should fetch the UserEntity, then get its userHandle (which should be consistent across credentials for that user).
+        // Or, if we decide UserIdentity.name used in registration *is* the userHandle, this is simpler.
+        // Let's assume the 'username' parameter here is the user's login username.
+        // We need a way to get a consistent user_handle for a given UsersEntity.
+        // For now, we'll query one of their passkeys and return its user_handle. This assumes all passkeys for a user share the same user_handle.
+        log.debug("Getting user handle for username (interpreted as login username): {}", username);
+        return passkeyCredentialRepository.findByUser_Email(username) // Need to add findByUser_Email to repository
+                .stream()
+                .findFirst()
+                .map(PasskeyCredentialEntity::getUserHandle)
+                .map(ByteArray::fromBase64Url); // Assuming userHandle is stored Base64URL encoded. If not, adjust.
+                                                // Yubico's UserIdentity.id is a ByteArray.
+    }
+
+    @Override
+    public Optional<String> getUsernameForUserHandle(ByteArray userHandle) {
+        // This should return the "login username" (e.g., email) associated with the given userHandle.
+        // We find a credential by userHandle, then get the associated UsersEntity's email.
+        log.debug("Getting username for user handle: {}", userHandle.getBase64Url());
+        return passkeyCredentialRepository.findByUserHandle(userHandle.getBase64Url())
+                .stream()
+                .findFirst()
+                .map(PasskeyCredentialEntity::getUser)
+                .map(UsersEntity::getEmail);
+    }
+
+    @Override
+    public Optional<RegisteredCredential> lookup(ByteArray credentialId, ByteArray userHandle) {
+        // Lookup a specific credential by its ID and the userHandle it was registered with.
+        log.debug("Looking up credential ID: {}, user handle: {}", credentialId.getBase64Url(), userHandle.getBase64Url());
+        return passkeyCredentialRepository.findByExternalIdAndUserHandle(credentialId.getBase64Url(), userHandle.getBase64Url()) // Need to add this method
+                .map(this::convertToRegisteredCredential);
+    }
+
+    @Override
+    public Set<RegisteredCredential> lookupAll(ByteArray credentialId) {
+        // Lookup all credentials that match a given credential ID.
+        // This is usually for discovering all users who might have registered a specific roaming authenticator.
+        log.debug("Looking up all credentials for ID: {}", credentialId.getBase64Url());
+        return passkeyCredentialRepository.findByExternalId(credentialId.getBase64Url()).stream()
+                .map(this::convertToRegisteredCredential)
+                .collect(Collectors.toSet());
+    }
+
+    private RegisteredCredential convertToRegisteredCredential(PasskeyCredentialEntity entity) {
+        return RegisteredCredential.builder()
+                .credentialId(ByteArray.fromBase64Url(entity.getExternalId()))
+                .userHandle(ByteArray.fromBase64Url(entity.getUserHandle())) // Assuming userHandle is stored Base64URL
+                .publicKeyCose(ByteArray.fromBase64Url(entity.getPublicKeyCose()))
+                .signatureCount(entity.getCount())
+                .build();
+    }
+
+    // Helper method to add to PasskeyCredentialRepository if it doesn't exist
+    // public List<PasskeyCredentialEntity> findByUser_Email(String email) - this would actually go in the repository interface
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/PasskeyService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/PasskeyService.java
@@ -1,0 +1,20 @@
+package com.n1netails.n1netails.api.service;
+
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyLoginFinishRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyLoginStartRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyRegistrationFinishRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyRegistrationStartRequest;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyAuthenticationResponse;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyLoginStartResponse;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyRegistrationStartResponse;
+
+public interface PasskeyService {
+
+    PasskeyRegistrationStartResponse startRegistration(PasskeyRegistrationStartRequest request);
+
+    void finishRegistration(PasskeyRegistrationFinishRequest request);
+
+    PasskeyLoginStartResponse startLogin(PasskeyLoginStartRequest request);
+
+    PasskeyAuthenticationResponse finishLogin(PasskeyLoginFinishRequest request);
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/PasskeyServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/PasskeyServiceImpl.java
@@ -1,0 +1,290 @@
+package com.n1netails.n1netails.api.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.exception.type.UsernameExistsException;
+import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.entity.PasskeyCredentialEntity;
+import com.n1netails.n1netails.api.model.entity.PasskeyRegistrationRequestEntity;
+import com.n1netails.n1netails.api.model.entity.UsersEntity;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyLoginFinishRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyLoginStartRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyRegistrationFinishRequest;
+import com.n1netails.n1netails.api.model.request.passkey.PasskeyRegistrationStartRequest;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyAuthenticationResponse;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyLoginStartResponse;
+import com.n1netails.n1netails.api.model.response.passkey.PasskeyRegistrationStartResponse;
+import com.n1netails.n1netails.api.repository.PasskeyCredentialRepository;
+import com.n1netails.n1netails.api.repository.PasskeyRegistrationRequestRepository;
+import com.n1netails.n1netails.api.repository.UserRepository;
+import com.n1netails.n1netails.api.service.PasskeyService;
+import com.yubico.webauthn.*;
+import com.yubico.webauthn.data.*;
+import com.yubico.webauthn.exception.AssertionFailedException;
+import com.yubico.webauthn.exception.RegistrationFailedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.core.GrantedAuthority;
+
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.n1netails.n1netails.api.constant.ProjectSecurityConstant.EXPIRATION_TIME;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasskeyServiceImpl implements PasskeyService {
+
+    private final RelyingParty relyingParty;
+    private final UserRepository userRepository;
+    private final PasskeyCredentialRepository passkeyCredentialRepository;
+    private final PasskeyRegistrationRequestRepository registrationRequestRepository;
+    private final ObjectMapper objectMapper; // For converting Yubico objects to JSON strings and vice-versa
+    private final JwtEncoder jwtEncoder;
+
+    private static final long REGISTRATION_REQUEST_EXPIRY_MINUTES = 5;
+
+
+    @Override
+    @Transactional
+    public PasskeyRegistrationStartResponse startRegistration(PasskeyRegistrationStartRequest request) {
+        log.info("Starting passkey registration for username: {}", request.getUsername());
+        UsersEntity user = userRepository.findUserByEmail(request.getUsername())
+                .orElseThrow(() -> new UserNotFoundException("User not found with email: " + request.getUsername()));
+
+        // Check if user already has passkeys and if we want to limit them or just add another
+        // For now, allow multiple passkeys per user.
+
+        // Generate a user handle for WebAuthn - this should be a stable, non-personally identifiable ID for the user.
+        // We can use the user's database ID or a generated UUID associated with the user.
+        // For Yubico's library, this user handle is what's stored in UserIdentity.id
+        // Let's use a base64url encoded version of user's primary ID for now.
+        // Important: This handle should be consistent for the user across all their credentials.
+        ByteArray userHandle = ByteArray.fromBase64Url(user.getUserId()); // Assuming UsersEntity.getUserId() returns a suitable string ID.
+
+        UserIdentity userIdentity = UserIdentity.builder()
+                .name(user.getEmail()) // Typically the username they log in with
+                .displayName(request.getDisplayName() != null ? request.getDisplayName() : user.getFirstName() + " " + user.getLastName())
+                .id(userHandle) // This is the UserHandle
+                .build();
+
+        StartRegistrationOptions registrationOptions = StartRegistrationOptions.builder()
+                .user(userIdentity)
+                .authenticatorSelection(AuthenticatorSelectionCriteria.builder()
+                        .residentKey(ResidentKeyRequirement.PREFERRED) // Prefer discoverable credentials
+                        .userVerification(UserVerificationRequirement.PREFERRED)
+                        .build())
+                .build();
+
+        PublicKeyCredentialCreationOptions creationOptions = relyingParty.startRegistration(registrationOptions);
+
+        try {
+            String optionsJson = creationOptions.toJson();
+            String requestId = creationOptions.getChallenge().getBase64Url(); // Use challenge as request ID
+
+            PasskeyRegistrationRequestEntity requestEntity = PasskeyRegistrationRequestEntity.builder()
+                    .requestId(requestId)
+                    .userId(user.getId())
+                    .username(user.getEmail())
+                    .registrationOptions(optionsJson)
+                    .build();
+            registrationRequestRepository.save(requestEntity);
+
+            log.info("Passkey registration started for user: {}, challenge: {}", user.getEmail(), requestId);
+            return new PasskeyRegistrationStartResponse(requestId, optionsJson);
+
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing PublicKeyCredentialCreationOptions to JSON", e);
+            throw new RuntimeException("Failed to start passkey registration due to JSON processing error.", e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void finishRegistration(PasskeyRegistrationFinishRequest request) {
+        log.info("Finishing passkey registration for request ID: {}", request.getRegistrationId());
+
+        PasskeyRegistrationRequestEntity requestEntity = registrationRequestRepository.findByRequestId(request.getRegistrationId())
+                .orElseThrow(() -> new RuntimeException("Passkey registration request not found or expired: " + request.getRegistrationId()));
+
+        // Clean up expired requests (optional, can be a scheduled task too)
+        registrationRequestRepository.deleteAllByCreatedAtBefore(OffsetDateTime.now().minusMinutes(REGISTRATION_REQUEST_EXPIRY_MINUTES + 5));
+
+
+        try {
+            PublicKeyCredential<AuthenticatorAttestationResponse, ClientRegistrationExtensionOutputs> pkc =
+                    PublicKeyCredential.parseRegistrationResponseJson(request.getCredential());
+
+            PublicKeyCredentialCreationOptions creationOptions = PublicKeyCredentialCreationOptions.fromJson(requestEntity.getRegistrationOptions());
+
+            RegistrationResult registrationResult = relyingParty.finishRegistration(FinishRegistrationOptions.builder()
+                    .request(creationOptions)
+                    .response(pkc)
+                    .build());
+
+            UsersEntity user = userRepository.findById(requestEntity.getUserId()) // Assuming userId was stored
+                    .orElseThrow(() -> new UserNotFoundException("User not found for registration request."));
+
+
+            // Check for existing friendly name for this user
+            String friendlyName = pkc.getClientExtensionResults().getCredProps() != null && pkc.getClientExtensionResults().getCredProps().isRk() ? "Discoverable Passkey" : "Passkey";
+            // Potentially allow user to name it or generate a default name
+            int count = 1;
+            String baseName = friendlyName;
+            while(passkeyCredentialRepository.existsByUserAndFriendlyName(user, friendlyName)) {
+                friendlyName = baseName + " " + (++count);
+            }
+
+
+            PasskeyCredentialEntity credentialEntity = PasskeyCredentialEntity.builder()
+                    .user(user)
+                    .externalId(registrationResult.getKeyId().getId().getBase64Url())
+                    .publicKeyCose(registrationResult.getPublicKeyCose().getBase64Url())
+                    .count(registrationResult.getSignatureCount())
+                    .aaguid(pkc.getResponse().getAttestation().getAuthenticatorData().getAaguid().getBase64Url()) // Store AAGUID
+                    .userHandle(creationOptions.getUser().getId().getBase64Url()) // Store the user handle used
+                    .credentialType("public-key") // Standard type
+                    .friendlyName(friendlyName) // Set a default friendly name
+                    .userAgent(null) // User-Agent should be captured from HTTP request if needed
+                    .build();
+            passkeyCredentialRepository.save(credentialEntity);
+            registrationRequestRepository.delete(requestEntity); // Clean up successful request
+
+            log.info("Passkey registration finished successfully for user: {}, credential ID: {}", user.getEmail(), credentialEntity.getExternalId());
+
+        } catch (JsonProcessingException e) {
+            log.error("Error processing JSON for passkey registration finish: {}", request.getRegistrationId(), e);
+            registrationRequestRepository.delete(requestEntity); // Clean up failed request
+            throw new RuntimeException("Failed to finish passkey registration due to JSON error.", e);
+        } catch (RegistrationFailedException e) {
+            log.warn("Passkey registration failed for request ID: {}. Reason: {}", request.getRegistrationId(), e.getMessage(), e);
+            registrationRequestRepository.delete(requestEntity); // Clean up failed request
+            throw new RuntimeException("Passkey registration failed: " + e.getMessage(), e);
+        }
+    }
+
+
+    @Override
+    @Transactional(readOnly = true) // Typically start of login is read-only
+    public PasskeyLoginStartResponse startLogin(PasskeyLoginStartRequest request) {
+        log.info("Starting passkey login for username: {}", request != null ? request.getUsername() : "N/A (discoverable)");
+
+        StartAssertionOptions.Builder optionsBuilder = StartAssertionOptions.builder();
+        if (request != null && request.getUsername() != null && !request.getUsername().trim().isEmpty()) {
+            optionsBuilder.username(request.getUsername());
+        }
+        // For discoverable credentials, username might not be provided initially.
+        // The RelyingParty library handles this.
+
+        PublicKeyCredentialRequestOptions requestOptions = relyingParty.startAssertion(optionsBuilder.build());
+
+        try {
+            String optionsJson = requestOptions.toJson();
+            String assertionId = requestOptions.getChallenge().getBase64Url(); // Use challenge as assertion ID
+
+            // We don't strictly need to store the assertion request for the Yubico library's server-side,
+            // as finishAssertion takes the challenge directly.
+            // However, if we wanted to link it to a user session or add expiry, we could store it.
+            // For simplicity here, we'll just return it. The client needs to send back the challenge (assertionId).
+
+            log.info("Passkey login started, challenge: {}", assertionId);
+            return new PasskeyLoginStartResponse(assertionId, optionsJson);
+
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing PublicKeyCredentialRequestOptions to JSON", e);
+            throw new RuntimeException("Failed to start passkey login due to JSON processing error.", e);
+        }
+    }
+
+    @Override
+    @Transactional
+    public PasskeyAuthenticationResponse finishLogin(PasskeyLoginFinishRequest request) {
+        log.info("Finishing passkey login for assertion ID (challenge): {}", request.getAssertionId());
+
+        try {
+            PublicKeyCredential<AuthenticatorAssertionResponse, ClientAssertionExtensionOutputs> pkc =
+                    PublicKeyCredential.parseAssertionResponseJson(request.getCredential());
+
+            FinishAssertionOptions finishOptions = FinishAssertionOptions.builder()
+                    .request(AssertionRequest.builder() // Build AssertionRequest from the challenge received
+                        .challenge(ByteArray.fromBase64Url(request.getAssertionId()))
+                        // .publicKeyCredentialRequestOptions( ... ) // If we stored the full options earlier, we could pass them.
+                                                                // Yubico lib can often work with just challenge + response.
+                        .build())
+                    .response(pkc)
+                    .build();
+
+            AssertionResult assertionResult = relyingParty.finishAssertion(finishOptions);
+
+            if (assertionResult.isSuccess()) {
+                PasskeyCredentialEntity credentialEntity = passkeyCredentialRepository
+                        .findByExternalId(pkc.getId().getBase64Url()) // pkc.getId() is the credential ID
+                        .stream().findFirst() // Assuming credential ID is globally unique
+                        .orElseThrow(() -> new AssertionFailedException("Authenticated passkey not found in repository."));
+
+                // Update signature count and last used time
+                credentialEntity.setCount(assertionResult.getSignatureCount());
+                credentialEntity.setLastUsedAt(OffsetDateTime.now());
+                passkeyCredentialRepository.save(credentialEntity);
+
+                UsersEntity user = credentialEntity.getUser();
+                UserPrincipal userPrincipal = new UserPrincipal(user); // Create UserPrincipal for token generation
+
+                String token = createToken(userPrincipal);
+
+                log.info("Passkey login successful for user: {}, credential ID: {}", user.getEmail(), credentialEntity.getExternalId());
+                return new PasskeyAuthenticationResponse(token, user.getEmail(), "Passkey login successful.");
+            } else {
+                log.warn("Passkey assertion failed for assertion ID: {}", request.getAssertionId());
+                throw new AssertionFailedException("Passkey assertion failed.");
+            }
+
+        } catch (JsonProcessingException e) {
+            log.error("Error processing JSON for passkey login finish: {}", request.getAssertionId(), e);
+            throw new RuntimeException("Failed to finish passkey login due to JSON error.", e);
+        } catch (AssertionFailedException e) {
+            log.warn("Passkey login failed for assertion ID: {}. Reason: {}", request.getAssertionId(), e.getMessage(), e);
+            throw new RuntimeException("Passkey login failed: " + e.getMessage(), e);
+        }
+    }
+
+    // Based on UserController's createToken method
+    private String createToken(UserPrincipal userPrincipal) {
+        JwtClaimsSet claimsSet = JwtClaimsSet.builder()
+                .issuer("self") // TODO: Make this configurable
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(EXPIRATION_TIME)) // EXPIRATION_TIME from ProjectSecurityConstant
+                .subject(userPrincipal.getUsername()) // This is the email
+                .claim("authorities", userPrincipal.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .collect(Collectors.toList()))
+                .claim("userId", ((UsersEntity)userPrincipal.getUser()).getUserId()) // Add user ID if needed by frontend
+                .claim("firstName", ((UsersEntity)userPrincipal.getUser()).getFirstName())
+                .claim("lastName", ((UsersEntity)userPrincipal.getUser()).getLastName())
+                .build();
+
+        JwtEncoderParameters parameters = JwtEncoderParameters.from(claimsSet);
+        return jwtEncoder.encode(parameters).getTokenValue();
+    }
+
+    // Method to clean up stale registration requests (can be called by a scheduler)
+    @Transactional
+    public void cleanupStaleRegistrationRequests() {
+        OffsetDateTime expiryTime = OffsetDateTime.now().minusMinutes(REGISTRATION_REQUEST_EXPIRY_MINUTES);
+        log.info("Cleaning up passkey registration requests older than {}", expiryTime);
+        registrationRequestRepository.deleteAllByCreatedAtBefore(expiryTime); // Returns void
+        log.info("Attempted deletion of stale passkey registration requests older than {}.", expiryTime);
+    }
+}

--- a/n1netails-api/src/main/resources/application.yml
+++ b/n1netails-api/src/main/resources/application.yml
@@ -34,3 +34,13 @@ management:
     web:
       exposure:
         include: health,info
+
+# WebAuthn Relying Party Configuration
+# Ensure these values are appropriate for your deployment environment.
+# For development, localhost is common. For production, use your actual domain.
+webauthn:
+  relying-party-id: "localhost" # This MUST match the domain from which your frontend is served (e.g., yourdomain.com)
+  relying-party-name: "N1netails Application" # A human-readable name for your application
+  relying-party-origins: "http://localhost:4200, http://localhost:9901" # Comma-separated list of allowed origins (frontend URL, API URL if different and involved)
+                                       # Example for production: "https://app.n1netails.com"
+                                       # The port might be important if it's non-standard for HTTP/HTTPS.

--- a/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-00010-create-table-passkey-credentials.xml
+++ b/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-00010-create-table-passkey-credentials.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="00010-create-table-passkey-credentials" author="jules">
+        <createTable tableName="passkey_credentials">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false" foreignKeyName="fk_passkey_credentials_user_id" references="users(id)"/>
+            </column>
+            <column name="external_id" type="VARCHAR(2048)"> <!-- Yubico library uses base64url encoding for this, can be long -->
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="public_key_cose" type="VARCHAR(2048)"> <!-- COSE public key, base64url encoded -->
+                <constraints nullable="false"/>
+            </column>
+            <column name="count" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="aaguid" type="VARCHAR(36)"> <!-- AAGUID is typically a UUID -->
+                <constraints nullable="true"/>
+            </column>
+            <column name="user_handle" type="VARCHAR(255)"> <!-- Store the user handle used during registration -->
+                 <constraints nullable="false"/>
+            </column>
+            <column name="credential_type" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_used_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_agent" type="VARCHAR(512)">
+                <constraints nullable="true"/>
+            </column>
+             <column name="friendly_name" type="VARCHAR(255)"> <!-- Optional: a name given by the user -->
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="passkey_registration_requests">
+            <column name="request_id" type="VARCHAR(255)"> <!-- This will store the challenge -->
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT"> <!-- Link to user if known, or use username -->
+                <constraints nullable="true"/>
+            </column>
+            <column name="username" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="registration_options" type="TEXT"> <!-- Store the JSON serialized PublicKeyCredentialCreationOptions -->
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createIndex tableName="passkey_credentials" indexName="idx_passkey_credentials_user_id">
+            <column name="user_id"/>
+        </createIndex>
+        <createIndex tableName="passkey_credentials" indexName="idx_passkey_credentials_user_handle">
+            <column name="user_handle"/>
+        </createIndex>
+         <createIndex tableName="passkey_registration_requests" indexName="idx_passkey_reg_requests_created_at">
+            <column name="created_at"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-master.xml
@@ -16,5 +16,6 @@
     <include file="db/changelog/db.changelog-00007-create-table-n1netoken.xml"/>
     <include file="db/changelog/db.changelog-00008-insert-n1netails-organization.xml"/>
     <include file="db/changelog/db.changelog-00009-alter-notes-table.xml"/>
+    <include file="db/changelog/db.changelog-00010-create-table-passkey-credentials.xml"/>
 
 </databaseChangeLog>

--- a/n1netails-ui/src/main/typescript/src/app/core/services/passkey-auth.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/core/services/passkey-auth.service.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment'; // Check if environment.ts exists and has apiUrl
+
+// Assuming DTO structures from backend for request/response types
+// These should ideally be in shared interfaces if you have a mono-repo or shared types library
+interface PasskeyRegistrationStartRequest {
+  username: string;
+  displayName?: string;
+}
+
+interface PasskeyRegistrationStartResponse {
+  registrationId: string;
+  options: any; // This will be parsed PublicKeyCredentialCreationOptions like structure
+}
+
+interface PasskeyRegistrationFinishRequest {
+  registrationId: string;
+  credential: any; // This will be the JSON representation of PublicKeyCredential
+}
+
+interface PasskeyLoginStartRequest {
+  username?: string;
+}
+
+interface PasskeyLoginStartResponse {
+  assertionId: string;
+  options: any; // This will be parsed PublicKeyCredentialRequestOptions like structure
+}
+
+interface PasskeyLoginFinishRequest {
+  assertionId: string;
+  credential: any; // This will be the JSON representation of PublicKeyCredential
+}
+
+interface PasskeyAuthenticationResponse {
+  token: string;
+  username: string;
+  message: string;
+}
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PasskeyAuthService {
+
+  private apiUrl = `${environment.apiUrl}/passkey`; // Ensure environment.apiUrl is set up
+
+  constructor(private http: HttpClient) {
+    // Check if environment.apiUrl is defined
+    if (!environment.apiUrl) {
+        console.warn('environment.apiUrl is not defined. PasskeyAuthService API calls may fail.');
+        this.apiUrl = `/api/v1/passkey`; // Fallback or ensure your proxy handles this
+    }
+  }
+
+  private getHeaders(): HttpHeaders {
+    // Add any standard headers if needed, e.g., for authorization if user is already partially logged in
+    // For passkey registration/login start, usually no prior auth token is needed.
+    return new HttpHeaders({
+      'Content-Type': 'application/json'
+    });
+  }
+
+  startRegistration(username: string, displayName?: string): Observable<PasskeyRegistrationStartResponse> {
+    const payload: PasskeyRegistrationStartRequest = { username, displayName };
+    return this.http.post<PasskeyRegistrationStartResponse>(`${this.apiUrl}/register/start`, payload, { headers: this.getHeaders() })
+      .pipe(catchError(this.handleError));
+  }
+
+  finishRegistration(payload: PasskeyRegistrationFinishRequest): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/register/finish`, payload, { headers: this.getHeaders() })
+      .pipe(catchError(this.handleError));
+  }
+
+  startLogin(username?: string): Observable<PasskeyLoginStartResponse> {
+    const payload: PasskeyLoginStartRequest = { username };
+    // For GET-like start login (if username in query param or no body) or POST with optional body:
+    // Adjust if your backend expects GET or POST with empty body for discoverable credentials
+    return this.http.post<PasskeyLoginStartResponse>(`${this.apiUrl}/login/start`, username ? payload : {}, { headers: this.getHeaders() })
+      .pipe(catchError(this.handleError));
+  }
+
+  finishLogin(payload: PasskeyLoginFinishRequest): Observable<PasskeyAuthenticationResponse> {
+    return this.http.post<PasskeyAuthenticationResponse>(`${this.apiUrl}/login/finish`, payload, { headers: this.getHeaders() })
+      .pipe(catchError(this.handleError));
+  }
+
+  private handleError(error: any): Observable<never> {
+    console.error('PasskeyAuthService error:', error);
+    // Customize error handling (e.g., user-friendly messages, logging)
+    let errorMessage = 'An unknown error occurred with Passkey authentication.';
+    if (error.error instanceof ErrorEvent) {
+      // Client-side or network error
+      errorMessage = `Error: ${error.error.message}`;
+    } else if (error.status) {
+      // Backend returned an unsuccessful response code
+      errorMessage = `Error Code: ${error.status}\nMessage: ${error.message || error.error?.message || error.error}`;
+      if (error.error && typeof error.error === 'object' && error.error.message) {
+        errorMessage = error.error.message; // Use specific error message from backend if available
+      } else if (typeof error.error === 'string') {
+        errorMessage = error.error;
+      }
+    }
+    return throwError(() => new Error(errorMessage));
+  }
+}

--- a/n1netails-ui/src/main/typescript/src/app/core/utils/webauthn.utils.ts
+++ b/n1netails-ui/src/main/typescript/src/app/core/utils/webauthn.utils.ts
@@ -1,0 +1,164 @@
+// Helper functions for WebAuthn browser API interactions
+
+/**
+ * Converts an ArrayBuffer to a Base64URL-encoded string.
+ * @param buffer The ArrayBuffer to convert.
+ * @returns A Base64URL-encoded string.
+ */
+export function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let str = '';
+  for (const charCode of bytes) {
+    str += String.fromCharCode(charCode);
+  }
+  const base64 = btoa(str);
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/**
+ * Converts a Base64URL-encoded string to an ArrayBuffer.
+ * @param base64Url The Base64URL-encoded string to convert.
+ * @returns An ArrayBuffer.
+ */
+export function base64UrlToArrayBuffer(base64Url: string): ArrayBuffer {
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (base64.length % 4)) % 4;
+  const paddedBase64 = base64 + '='.repeat(padLength);
+  const binaryStr = atob(paddedBase64);
+  const buffer = new ArrayBuffer(binaryStr.length);
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < binaryStr.length; i++) {
+    bytes[i] = binaryStr.charCodeAt(i);
+  }
+  return buffer;
+}
+
+/**
+ * Prepares PublicKeyCredentialCreationOptions received from the server
+ * for `navigator.credentials.create()`.
+ * Specifically, it converts challenge and user.id from Base64URL to ArrayBuffer.
+ * It also converts excludeCredentials[*].id from Base64URL to ArrayBuffer.
+ * @param options The options from the server.
+ * @returns The options ready for the browser API.
+ */
+export function prepareCreationOptions(options: any): PublicKeyCredentialCreationOptions {
+  const preparedOptions = { ...options };
+
+  preparedOptions.challenge = base64UrlToArrayBuffer(options.challenge);
+  if (options.user && options.user.id) {
+    preparedOptions.user.id = base64UrlToArrayBuffer(options.user.id);
+  }
+
+  if (options.excludeCredentials) {
+    preparedOptions.excludeCredentials = options.excludeCredentials.map((cred: any) => ({
+      ...cred,
+      id: base64UrlToArrayBuffer(cred.id),
+    }));
+  }
+
+  // Ensure pubKeyCredParams is correctly structured if not already
+  if (options.pubKeyCredParams) {
+    preparedOptions.pubKeyCredParams = options.pubKeyCredParams.map((param: any) => ({
+        type: param.type as PublicKeyCredentialType,
+        alg: param.alg as number
+    }));
+  }
+
+
+  return preparedOptions as PublicKeyCredentialCreationOptions;
+}
+
+/**
+ * Prepares PublicKeyCredentialRequestOptions received from the server
+ * for `navigator.credentials.get()`.
+ * Specifically, it converts challenge and allowCredentials[*].id from Base64URL to ArrayBuffer.
+ * @param options The options from the server.
+ * @returns The options ready for the browser API.
+ */
+export function prepareRequestOptions(options: any): PublicKeyCredentialRequestOptions {
+  const preparedOptions = { ...options };
+  preparedOptions.challenge = base64UrlToArrayBuffer(options.challenge);
+  if (options.allowCredentials) {
+    preparedOptions.allowCredentials = options.allowCredentials.map((cred: any) => ({
+      ...cred,
+      id: base64UrlToArrayBuffer(cred.id),
+    }));
+  }
+  return preparedOptions as PublicKeyCredentialRequestOptions;
+}
+
+/**
+ * Converts the browser's PublicKeyCredential object obtained from navigator.credentials.create()
+ * into a JSON-serializable object to send to the server for finishing registration.
+ * @param pubKeyCred The PublicKeyCredential object from the browser.
+ * @returns A JSON-serializable object.
+ */
+export function publicKeyCredentialToJSON(pubKeyCred: PublicKeyCredential): any {
+    if (pubKeyCred instanceof PublicKeyCredential && pubKeyCred.response instanceof AuthenticatorAttestationResponse) {
+        return {
+            id: pubKeyCred.id,
+            rawId: arrayBufferToBase64Url(pubKeyCred.rawId),
+            type: pubKeyCred.type,
+            response: {
+                clientDataJSON: arrayBufferToBase64Url(pubKeyCred.response.clientDataJSON),
+                attestationObject: arrayBufferToBase64Url(pubKeyCred.response.attestationObject),
+                // transports: pubKeyCred.response.getTransports ? pubKeyCred.response.getTransports() : [], // getTransports() might not be available on all types
+            },
+            clientExtensionResults: pubKeyCred.getClientExtensionResults(), // This should be JSON serializable
+        };
+    } else if (pubKeyCred instanceof PublicKeyCredential && pubKeyCred.response instanceof AuthenticatorAssertionResponse) {
+         return {
+            id: pubKeyCred.id,
+            rawId: arrayBufferToBase64Url(pubKeyCred.rawId),
+            type: pubKeyCred.type,
+            response: {
+                clientDataJSON: arrayBufferToBase64Url(pubKeyCred.response.clientDataJSON),
+                authenticatorData: arrayBufferToBase64Url(pubKeyCred.response.authenticatorData),
+                signature: arrayBufferToBase64Url(pubKeyCred.response.signature),
+                userHandle: pubKeyCred.response.userHandle ? arrayBufferToBase64Url(pubKeyCred.response.userHandle) : null,
+            },
+            clientExtensionResults: pubKeyCred.getClientExtensionResults(),
+        };
+    }
+    throw new Error('Invalid PublicKeyCredential type');
+}
+
+// Export interfaces for better type safety if not already globally available or defined elsewhere
+// For example, if you don't have @types/web Earenabled or they are outdated:
+/*
+interface PublicKeyCredentialCreationOptionsJSON {
+    rp: PublicKeyCredentialRpEntity;
+    user: PublicKeyCredentialUserEntityJSON;
+    challenge: string; // Base64URL
+    pubKeyCredParams: PublicKeyCredentialParameters[];
+    timeout?: number;
+    excludeCredentials?: PublicKeyCredentialDescriptorJSON[];
+    authenticatorSelection?: AuthenticatorSelectionCriteria;
+    attestation?: AttestationConveyancePreference;
+    extensions?: AuthenticationExtensionsClientInputs;
+}
+
+interface PublicKeyCredentialUserEntityJSON extends PublicKeyCredentialEntity {
+    id: string; // Base64URL
+    displayName: string;
+}
+
+interface PublicKeyCredentialDescriptorJSON {
+    type: PublicKeyCredentialType;
+    id: string; // Base64URL
+    transports?: AuthenticatorTransport[];
+}
+*/
+
+/* Example usage for parsing server response before navigator.credentials.create():
+fetch('/start-registration', { method: 'POST', body: JSON.stringify({ username }), headers })
+  .then(res => res.json())
+  .then(optionsFromServer => {
+    const createOptions = prepareCreationOptions(optionsFromServer.options); // Assuming optionsFromServer.options is the PublicKeyCredentialCreationOptions like object
+    return navigator.credentials.create({ publicKey: createOptions });
+  })
+  .then(credential => {
+    const credentialForServer = publicKeyCredentialToJSON(credential);
+    return fetch('/finish-registration', { method: 'POST', body: JSON.stringify(credentialForServer), headers });
+  });
+*/

--- a/n1netails-ui/src/main/typescript/src/app/pages/login/login.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/login/login.component.html
@@ -41,8 +41,22 @@
       [disabled]="!loginForm.valid"
       type="submit"
     >
-      Login
+      Login with Password
     </button>
+
+    <div class="or-divider">
+      <span>OR</span>
+    </div>
+
+    <button
+      nz-button
+      type="button"
+      class="passkey-btn"
+      (click)="onLoginWithPasskey(loginForm)"
+    >
+      <i nz-icon nzType="fingerprint" nzTheme="outline"></i> Login with Passkey
+    </button>
+
     <div class="register-link">
       <span>Don't have an account?</span>
       <a routerLink="/register">Register here</a>

--- a/n1netails-ui/src/main/typescript/src/app/pages/login/login.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/login/login.component.ts
@@ -8,6 +8,8 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { HeaderType } from '../../model/enum/header-type.enum';
 import { NzFormModule } from 'ng-zorro-antd/form';
 import { NzNotificationService } from 'ng-zorro-antd/notification';
+import { PasskeyAuthService } from '../../core/services/passkey-auth.service'; // Added
+import * as WebAuthnUtils from '../../core/utils/webauthn.utils'; // Added
 
 @Component({
   selector: 'app-login',
@@ -23,7 +25,8 @@ export class LoginComponent implements OnInit, OnDestroy {
   constructor(
     private notification: NzNotificationService,
     private authenticationService: AuthenticationService,
-    private router: Router
+    private router: Router,
+    private passkeyAuthService: PasskeyAuthService // Added
   ) {}
 
   ngOnInit(): void {
@@ -67,5 +70,96 @@ export class LoginComponent implements OnInit, OnDestroy {
     const token = response.headers.get(HeaderType.JWT_TOKEN) || "";
     this.authenticationService.saveToken(token);
     this.authenticationService.addUserToLocalCache(response.body || null);
+  }
+
+  public async onLoginWithPasskey(form: NgForm): Promise<void> {
+    // Username (email) from form can be used as a hint, but not strictly required for discoverable credentials
+    const username = form.value.email;
+    this.isLoading = true;
+
+    try {
+      // 1. Start passkey login
+      // Pass username if available, otherwise backend should handle discoverable credentials flow
+      const startResponse = await this.passkeyAuthService.startLogin(username || undefined).toPromise();
+      if (!startResponse || !startResponse.options) {
+        throw new Error('Failed to get login options from server.');
+      }
+
+      // 2. Prepare options and call navigator.credentials.get()
+      const credentialRequestOptions = WebAuthnUtils.prepareRequestOptions(JSON.parse(startResponse.options));
+
+      let credential;
+      try {
+        credential = await navigator.credentials.get({ publicKey: credentialRequestOptions });
+      } catch (err: any) {
+        console.error('navigator.credentials.get() error:', err);
+        this.presentToast(`Passkey selection failed: ${err.message || 'No authenticator was selected or an error occurred.'}`);
+        this.isLoading = false;
+        return;
+      }
+
+      if (!credential) {
+        this.presentToast('Passkey selection was cancelled or failed.');
+        this.isLoading = false;
+        return;
+      }
+
+      // 3. Convert credential to JSON and finish login
+      const credentialForServer = WebAuthnUtils.publicKeyCredentialToJSON(credential as PublicKeyCredential);
+
+      const authResponse = await this.passkeyAuthService.finishLogin({
+        assertionId: startResponse.assertionId,
+        credential: JSON.stringify(credentialForServer)
+      }).toPromise();
+
+      if (authResponse && authResponse.token) {
+        // Manually construct a HttpResponse-like object to reuse saveUser
+        const fakeResponse: Partial<HttpResponse<User>> = {
+          headers: { get: (headerName: string) => headerName === HeaderType.JWT_TOKEN ? authResponse.token : null } as any,
+          body: { // Construct a partial User object based on what PasskeyAuthenticationResponse provides
+            // This might need adjustment based on what `addUserToLocalCache` actually needs
+            // and what `PasskeyAuthenticationResponse` contains.
+            // For now, assume username from authResponse.username is enough for local cache.
+            // A more robust solution might involve fetching full user details after passkey login.
+            email: authResponse.username,
+            // Other User fields would be undefined here unless fetched separately
+          } as User
+        };
+        this.authenticationService.saveToken(authResponse.token);
+        // If PasskeyAuthenticationResponse contains enough user details, use them.
+        // Otherwise, addUserToLocalCache might need to be adapted or a separate user fetch call made.
+        // For now, creating a minimal user object for the cache.
+        const minimalUser: User = {
+            userId: '', // Not available from passkey response directly
+            firstName: '', // Not available
+            lastName: '', // Not available
+            username: authResponse.username,
+            email: authResponse.username, // Assuming username is email
+            profileImageUrl: '', // Not available
+            lastLoginDateDisplay: null,
+            joinDate: null,
+            role: '', // Role might need to be parsed from token or fetched
+            authorities: [], // Authorities from token
+            active: true,
+            notLocked: true,
+            enabled: true,
+            organizations: []
+        };
+        this.authenticationService.addUserToLocalCache(minimalUser);
+
+
+        this.notification.success('Success', 'Logged in successfully with Passkey!', { nzPlacement: 'topRight' });
+        this.router.navigateByUrl('/dashboard');
+        form.resetForm();
+      } else {
+        throw new Error('Passkey login failed: No token received.');
+      }
+
+    } catch (error: any) {
+      console.error('Passkey login process error: ', error);
+      this.presentToast(`Passkey login failed: ${error.message || 'An unknown error occurred.'}`);
+    } finally {
+      this.isLoading = false;
+    }
   }
 }

--- a/n1netails-ui/src/main/typescript/src/app/pages/register/register.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/register/register.component.html
@@ -56,8 +56,23 @@
       [disabled]="!registerForm.valid"
       type="submit"
     >
-      Register
+      Register with Password
     </button>
+
+    <div class="or-divider">
+      <span>OR</span>
+    </div>
+
+    <button
+      nz-button
+      type="button"
+      class="passkey-btn"
+      (click)="onRegisterWithPasskey(registerForm)"
+      [disabled]="!registerForm.get('username')?.valid || !registerForm.get('email')?.valid"
+    >
+      <i nz-icon nzType="fingerprint" nzTheme="outline"></i> Register with Passkey
+    </button>
+
     <div class="register-link">
       <span>Already have an account?</span>
       <a routerLink="/login">Login here</a>

--- a/n1netails-ui/src/main/typescript/src/app/pages/register/register.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/register/register.component.ts
@@ -8,6 +8,8 @@ import { AuthenticationService } from '../../service/authentication.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { HeaderType } from '../../model/enum/header-type.enum';
 import { NzNotificationService } from 'ng-zorro-antd/notification';
+import { PasskeyAuthService } from '../../core/services/passkey-auth.service'; // Added
+import * as WebAuthnUtils from '../../core/utils/webauthn.utils'; // Added
 
 @Component({
   selector: 'app-register',


### PR DESCRIPTION
Adds passkey (FIDO2/WebAuthn) registration and login functionality.

Backend (n1netails-api & n1netails-liquibase):
- Added Yubico WebAuthn server libraries.
- Created Liquibase changelog for `passkey_credentials` and `passkey_registration_requests` tables.
- Implemented DTOs, `PasskeyController` (endpoints: /register/start, /register/finish, /login/start, /login/finish), and `PasskeyService` for WebAuthn flows.
- Configured `RelyingParty` bean and `AppCredentialRepository` adapter.
- Added Relying Party settings to `application.yml`.
- Integrated JWT generation for successful passkey login.

Frontend (n1netails-ui):
- Created `PasskeyAuthService` to handle API communication.
- Added `webauthn.utils.ts` for ArrayBuffer/Base64URL conversions and preparing WebAuthn API options/results.
- Updated Register and Login components (`.html` and `.ts`) to include "Register with Passkey" and "Login with Passkey" buttons and associated logic using `navigator.credentials.create()` and `navigator.credentials.get()`.
- Updated `environment.ts` usage in the new service.