### PR TITLE
Remove all user email logging from passkey API logs

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasskeyController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasskeyController.java
@@ -41,18 +41,18 @@ public class PasskeyController {
 
         if (userPrincipal.getUser().getEmail().equals(request.getEmail())) {
             try {
-                log.info("Received request to start passkey registration for email: {}", request.getEmail());
+                log.info("User {} starting passkey registration for their own account.", userPrincipal.getUsername());
                 PasskeyRegistrationStartResponseDto response = passkeyService.startRegistration(request);
                 return ResponseEntity.ok(response);
             } catch (UserNotFoundException e) {
-                log.warn("User not found during start passkey registration: {}", request.getEmail(), e);
+                log.warn("User {} not found during start passkey registration. Details: {}", userPrincipal.getUsername(), e.getMessage());
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
             } catch (Exception e) {
-                log.error("Error starting passkey registration for email: {}", request.getEmail(), e);
+                log.error("Error starting passkey registration for user {}. Error: {}", userPrincipal.getUsername(), e.getMessage(), e);
                 throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error starting passkey registration", e);
             }
         } else {
-            log.warn("User {} attempted to register a passkey of user {} via /register/start endpoint.", userPrincipal.getUsername(), request.getEmail());
+            log.warn("User {} (ID: {}) attempted to register a passkey for a different target user account via /register/start endpoint. Denied.", userPrincipal.getUsername(), userPrincipal.getUserId());
             throw new AccessDeniedException("You can only register passkeys for your own account using this endpoint.");
         }
     }
@@ -61,7 +61,7 @@ public class PasskeyController {
     @PostMapping(value = "/register/finish", consumes = APPLICATION_JSON)
     public ResponseEntity<PasskeyApiResponseDto> finishRegistration(@RequestBody PasskeyRegistrationFinishRequestDto request) {
         try {
-            log.info("Received request to finish passkey registration with flowId: {}", request.getFlowId());
+            log.info("Received request to finish passkey registration with flowId: {}", request.getFlowId()); // flowId is likely okay to log as it's temporary
             boolean success = passkeyService.finishRegistration(request);
             if (success) {
                 return ResponseEntity.ok(new PasskeyApiResponseDto(true, "Passkey registration successful."));
@@ -69,11 +69,11 @@ public class PasskeyController {
                 return ResponseEntity.badRequest().body(new PasskeyApiResponseDto(false, "Passkey registration failed."));
             }
         } catch (UserNotFoundException e) {
-             log.warn("User not found during finish passkey registration for flowId: {}", request.getFlowId(), e);
+             log.warn("User not found during finish passkey registration for flowId: {}. Details: {}", request.getFlowId(), e.getMessage());
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
         }
         catch (Exception e) {
-            log.error("Error finishing passkey registration with flowId: {}", request.getFlowId(), e);
+            log.error("Error finishing passkey registration with flowId: {}. Error: {}", request.getFlowId(), e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new PasskeyApiResponseDto(false, "Error finishing passkey registration: " + e.getMessage()));
         }
@@ -84,13 +84,20 @@ public class PasskeyController {
     public ResponseEntity<PasskeyAuthenticationStartResponseDto> startAuthentication(@RequestBody(required = false) PasskeyAuthenticationStartRequestDto request) {
         // Request can be null or empty for discoverable credentials (passkeys)
         PasskeyAuthenticationStartRequestDto actualRequest = (request == null) ? new PasskeyAuthenticationStartRequestDto() : request;
+        String logIdentifier;
+        if (actualRequest.getEmail() != null && !actualRequest.getEmail().isBlank()) {
+            logIdentifier = "user (email provided for hint)";
+        } else {
+            logIdentifier = "discoverable credential user";
+        }
+
         try {
-            log.info("Received request to start passkey authentication for email: {}", actualRequest.getEmail());
+            log.info("Received request to start passkey authentication for {}.", logIdentifier);
             PasskeyAuthenticationStartResponseDto response = passkeyService.startAuthentication(actualRequest);
-            log.info("RETURNING START PASSKEY AUTHENTICATION RESPONSE");
+            log.info("Returning start passkey authentication response for {}.", logIdentifier);
             return ResponseEntity.ok(response);
         } catch (Exception e) {
-            log.error("Error starting passkey authentication for email: {}", actualRequest.getEmail(), e);
+            log.error("Error starting passkey authentication for {}. Error: {}", logIdentifier, e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error starting passkey authentication", e);
         }
     }
@@ -98,19 +105,18 @@ public class PasskeyController {
     @Operation(summary = "Finish Passkey Authentication", description = "Completes the passkey authentication process and returns a JWT if successful.")
     @PostMapping(value = "/login/finish", consumes = APPLICATION_JSON)
     public ResponseEntity<PasskeyAuthenticationResponseDto> finishAuthentication(@RequestBody PasskeyAuthenticationFinishRequestDto request) {
-        log.info("FINISH PASSKEY AUTHENTICATION");
+        log.info("Received request to finish passkey authentication with flowId: {}", request.getFlowId()); // flowId is likely okay to log
         try {
-            log.info("Received request to finish passkey authentication with flowId: {}", request.getFlowId());
             PasskeyAuthenticationResponseDto response = passkeyService.finishAuthentication(request);
             if (response.isSuccess()) {
-                log.info("RETURNING FINISH PASSKEY AUTHENTICATION RESPONSE");
+                log.info("Successfully finished passkey authentication for flowId: {}", request.getFlowId());
                 return ResponseEntity.ok(response);
             } else {
-                // Consider if specific errors from service layer should map to different HTTP statuses
+                log.warn("Passkey authentication failed for flowId: {}. Reason: {}", request.getFlowId(), response.getMessage());
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
             }
         } catch (Exception e) {
-            log.error("Error finishing passkey authentication with flowId: {}", request.getFlowId(), e);
+            log.error("Error finishing passkey authentication with flowId: {}. Error: {}", request.getFlowId(), e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(new PasskeyAuthenticationResponseDto(false, "Error finishing passkey authentication: " + e.getMessage()));
         }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasskeyController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/PasskeyController.java
@@ -52,7 +52,7 @@ public class PasskeyController {
                 throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error starting passkey registration", e);
             }
         } else {
-            log.warn("User {} (ID: {}) attempted to register a passkey for a different target user account via /register/start endpoint. Denied.", userPrincipal.getUsername(), userPrincipal.getUserId());
+            log.warn("User {} attempted to register a passkey for a different target user account via /register/start endpoint. Denied.", userPrincipal.getUsername());
             throw new AccessDeniedException("You can only register passkeys for your own account using this endpoint.");
         }
     }
@@ -61,7 +61,7 @@ public class PasskeyController {
     @PostMapping(value = "/register/finish", consumes = APPLICATION_JSON)
     public ResponseEntity<PasskeyApiResponseDto> finishRegistration(@RequestBody PasskeyRegistrationFinishRequestDto request) {
         try {
-            log.info("Received request to finish passkey registration with flowId: {}", request.getFlowId()); // flowId is likely okay to log as it's temporary
+            log.info("Received request to finish passkey registration with flowId: {}", request.getFlowId());
             boolean success = passkeyService.finishRegistration(request);
             if (success) {
                 return ResponseEntity.ok(new PasskeyApiResponseDto(true, "Passkey registration successful."));
@@ -105,7 +105,7 @@ public class PasskeyController {
     @Operation(summary = "Finish Passkey Authentication", description = "Completes the passkey authentication process and returns a JWT if successful.")
     @PostMapping(value = "/login/finish", consumes = APPLICATION_JSON)
     public ResponseEntity<PasskeyAuthenticationResponseDto> finishAuthentication(@RequestBody PasskeyAuthenticationFinishRequestDto request) {
-        log.info("Received request to finish passkey authentication with flowId: {}", request.getFlowId()); // flowId is likely okay to log
+        log.info("Received request to finish passkey authentication with flowId: {}", request.getFlowId());
         try {
             PasskeyAuthenticationResponseDto response = passkeyService.finishAuthentication(request);
             if (response.isSuccess()) {

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/impl/YubicoCredentialRepositoryImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/impl/YubicoCredentialRepositoryImpl.java
@@ -77,6 +77,9 @@ public class YubicoCredentialRepositoryImpl implements CredentialRepository {
                     return PublicKeyCredentialDescriptor.builder()
                             .id(reg.getCredential().getCredentialId())
                             .type(PublicKeyCredentialType.PUBLIC_KEY)
+                            // TODO LOOK INTO UNDERSTANDING AND IMPLEMENTING TRANSPORTS
+                            // Optionally include transports if you have them, e.g.:
+                            // .transports(reg.getTransports())
                             .build();
                 })
                 .collect(Collectors.toSet());
@@ -104,8 +107,6 @@ public class YubicoCredentialRepositoryImpl implements CredentialRepository {
     public Optional<String> getUsernameForUserHandle(ByteArray userHandle) {
         log.info("== getUsernameForUserHandle for userHandle (first 8 bytes): {}",
                 userHandle != null ? Base64.getEncoder().encodeToString(Arrays.copyOf(userHandle.getBytes(), 8)) : "N/A");
-        // log.info("userHandle: {}", userHandle); // Sensitive
-        // log.info("userHandle bytes: {}", userHandle.getBytes()); // Sensitive
 
         log.debug("Attempting to find passkey by userHandle (first 8 bytes): {}",
                 userHandle != null ? Base64.getEncoder().encodeToString(Arrays.copyOf(userHandle.getBytes(), 8)) : "N/A");
@@ -154,16 +155,11 @@ public class YubicoCredentialRepositoryImpl implements CredentialRepository {
         log.info("== lookup for credentialId (first 8 bytes): {} and userHandle (first 8 bytes): {}",
                 credentialId != null ? Base64.getEncoder().encodeToString(Arrays.copyOf(credentialId.getBytes(), 8)) : "N/A",
                 userHandle != null ? Base64.getEncoder().encodeToString(Arrays.copyOf(userHandle.getBytes(), 8)) : "N/A");
-        // log.info("finding by credential id: {}", credentialId); // Sensitive
-        // log.info("finding by credential id base 64 url: {}", credentialId.getBase64Url()); // Sensitive
-        // log.info("userHandle: {}", userHandle); // Sensitive
 
         Optional<PasskeySummary> optionalPasskeySummary = passkeyCredentialRepository.findPasskeyByCredentialId(credentialId.getBytes());
         if (optionalPasskeySummary.isPresent()) {
             PasskeySummary passkeySummary = optionalPasskeySummary.get();
-            // log.info("passkey summary: {}", optionalPasskeySummary.get()); // Sensitive: contains full credentialId, userHandle, publicKeyCose
             log.debug("Found passkey summary for credentialId (first 8 bytes): {}", Base64.getEncoder().encodeToString(Arrays.copyOf(passkeySummary.getCredentialId(), 8)));
-            // log.info("Credential ID: {}", Base64.getUrlEncoder().encodeToString(passkeySummary.getCredentialId())); // Sensitive
 
             RegisteredCredential registeredCredential = RegisteredCredential.builder()
                     .credentialId(new ByteArray(passkeySummary.getCredentialId()))
@@ -171,7 +167,6 @@ public class YubicoCredentialRepositoryImpl implements CredentialRepository {
                     .publicKeyCose(new ByteArray(passkeySummary.getPublicKeyCose()))
                     .signatureCount(passkeySummary.getSignatureCount())
                     .build();
-            // log.info("REGISTERED CREDENTIAL: {}", registeredCredential); // Sensitive: contains credentialId, userHandle, publicKeyCose
             log.info("Successfully looked up RegisteredCredential for credentialId (first 8 bytes): {}", Base64.getEncoder().encodeToString(Arrays.copyOf(credentialId.getBytes(), 8)));
             return Optional.of(registeredCredential);
         } else {
@@ -187,7 +182,6 @@ public class YubicoCredentialRepositoryImpl implements CredentialRepository {
     public Set<RegisteredCredential> lookupAll(ByteArray userHandle) {
         log.info("== lookupAll for userHandle (first 8 bytes): {}",
                 userHandle != null ? Base64.getEncoder().encodeToString(Arrays.copyOf(userHandle.getBytes(), 8)) : "N/A");
-        // log.info("userHandle: {}", userHandle); // Sensitive
         return getRegistrationsByUserHandle(userHandle).stream()
                 .map(CredentialRegistration::getCredential)
                 .collect(Collectors.toSet());
@@ -199,7 +193,6 @@ public class YubicoCredentialRepositoryImpl implements CredentialRepository {
         log.debug("== toCredentialRegistration for PasskeySummary with credentialId (first 8 bytes): {}",
                 passkeySummary != null && passkeySummary.getCredentialId() != null ?
                         Base64.getEncoder().encodeToString(Arrays.copyOf(passkeySummary.getCredentialId(), 8)) : "N/A");
-        // log.info("passkey summary: {}", passkeySummary); // Sensitive
 
         UsersEntity user = userRepository.findUserById(passkeySummary.getUserId());
         log.debug("User {} found for passkey summary.", user.getUsername());

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/PasskeyServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/PasskeyServiceImpl.java
@@ -134,8 +134,8 @@ public class PasskeyServiceImpl implements PasskeyService {
         PublicKeyCredentialCreationOptions credentialCreationOptions = relyingParty.startRegistration(options);
         String flowId = generateFlowId();
         registrationCache.put(flowId, credentialCreationOptions);
-        log.info("registration cache flow id: {}", flowId);
-        log.info("Started passkey registration for user: {}, flowId: {}", user.getUsername(), flowId);
+        log.info("Registration cache populated for flowId: {}", flowId);
+        log.info("Started passkey registration process for user with handle: {}, flowId: {}", user.getUserHandle(), flowId);
         return new PasskeyRegistrationStartResponseDto(flowId, credentialCreationOptions);
     }
 
@@ -143,53 +143,52 @@ public class PasskeyServiceImpl implements PasskeyService {
     @Transactional
     public boolean finishRegistration(PasskeyRegistrationFinishRequestDto request) throws UserNotFoundException {
 
-        log.info("finish registration public key credentials creation options");
+        log.info("Attempting to finish passkey registration for flowId: {}", request.getFlowId());
         PublicKeyCredentialCreationOptions creationOptions = registrationCache.getIfPresent(request.getFlowId());
         if (creationOptions == null) {
             log.warn("Passkey registration flow ID {} not found or expired.", request.getFlowId());
             return false;
         }
-        // Do NOT invalidate from cache immediately, finishRegistration might need it if it internally calls credentialRepository methods that check the cache
 
-        log.info("RETRIEVING REGISTRATION RESULT");
+        log.debug("Retrieved PublicKeyCredentialCreationOptions from cache for flowId: {}", request.getFlowId());
         try {
             RegistrationResult registrationResult = relyingParty.finishRegistration(FinishRegistrationOptions.builder()
                     .request(creationOptions)
                     .response(request.getCredential())
                     .build());
 
-            log.info("extracting user entity");
-            // User with email should exist as it was checked in startRegistration
+            log.info("Successfully processed finishRegistration with relying party for flowId: {}", request.getFlowId());
+
+            // creationOptions.getUser().getName() is the email.
+            // creationOptions.getUser().getId() is the user handle (ByteArray).
             UsersEntity user = userRepository.findUserByEmail(creationOptions.getUser().getName())
-                 .orElseThrow(() -> new UserNotFoundException("User " + creationOptions.getUser().getName() + " not found during finish registration."));
+                 .orElseThrow(() -> {
+                     log.error("User (email associated with user handle {}) not found during finish registration for flowId: {}. User handle from options: {}",
+                             creationOptions.getUser().getId().getBase64Url(), request.getFlowId(), creationOptions.getUser().getId().getBase64Url());
+                     return new UserNotFoundException("User associated with passkey registration options not found.");
+                 });
+            log.debug("User entity (username: {}) retrieved for user handle {} during finishRegistration.", user.getUsername(), creationOptions.getUser().getId().getBase64Url());
 
-
-            log.info("passkey credential entity");
             PasskeyCredentialEntity passkeyCredential = new PasskeyCredentialEntity();
             passkeyCredential.setUser(user);
             passkeyCredential.setCredentialId(registrationResult.getKeyId().getId().getBytes());
-            log.info("REGISTRATION RESULT PUBLIC KEY COSE: {}", registrationResult.getPublicKeyCose().getBytes());
+            // log.info("REGISTRATION RESULT PUBLIC KEY COSE: {}", registrationResult.getPublicKeyCose().getBytes()); // Sensitive
             byte[] pkBytes = registrationResult.getPublicKeyCose().getBytes();
             passkeyCredential.setPublicKeyCose(pkBytes);
 
             passkeyCredential.setSignatureCount(registrationResult.getSignatureCount());
-            passkeyCredential.setUserHandle(creationOptions.getUser().getId().getBytes()); // Store the user handle used during registration
-            passkeyCredential.setAttestationType(getAttestationType(request.getCredential())); // Helper to extract
+            passkeyCredential.setUserHandle(creationOptions.getUser().getId().getBytes());
+            passkeyCredential.setAttestationType(getAttestationType(request.getCredential()));
             passkeyCredential.setRegisteredAt(new Date());
-            passkeyCredential.setLastUsedAt(new Date()); // Set last used to now
+            passkeyCredential.setLastUsedAt(new Date());
             passkeyCredential.setBackupEligible(registrationResult.isBackupEligible());
             passkeyCredential.setBackupState(registrationResult.isBackedUp());
-
-            // User Verification (uvInitialized) can be tricky.
-            // The client indicates if UV was performed. The authenticator data flag (UV) reflects this.
-            // `registrationResult.isUserVerified()` reflects the UV flag from authenticator data.
             passkeyCredential.setUvInitialized(registrationResult.isUserVerified());
-
 
             if (request.getFriendlyName() != null && !request.getFriendlyName().isBlank()) {
                 passkeyCredential.setDeviceName(request.getFriendlyName());
             } else {
-                 passkeyCredential.setDeviceName("Passkey"); // Default name
+                 passkeyCredential.setDeviceName("Passkey");
             }
 
             Set<String> transports = request.getCredential().getResponse().getTransports()
@@ -205,15 +204,17 @@ public class PasskeyServiceImpl implements PasskeyService {
 
             attData.ifPresent(ad -> passkeyCredential.setAaguid(UUID.nameUUIDFromBytes(ad.getAaguid().getBytes())));
 
-            log.info("ATTEMPTING PASSKEY CREDENTIAL REPOSITORY SAVE");
+            log.info("Attempting to save new passkey credential for user: {}", user.getUsername());
             passkeyCredentialRepository.savePasskeyCredential(passkeyCredential);
-            registrationCache.invalidate(request.getFlowId()); // Invalidate after successful save
-            log.info("Successfully registered passkey for user: {}, credentialId: {}", user.getUsername(), passkeyCredential.getCredentialId());
+            registrationCache.invalidate(request.getFlowId());
+            log.info("Successfully registered passkey for user: {}. Credential ID (first 8 bytes): {}", user.getUsername(),
+                    Base64.getEncoder().encodeToString(Arrays.copyOf(passkeyCredential.getCredentialId(), 8)));
             return true;
         } catch (RegistrationFailedException e) {
-            registrationCache.invalidate(request.getFlowId()); // Invalidate on failure too
-            log.error("Passkey registration failed for user: {}. Reason: {}", creationOptions.getUser().getName(), e.getMessage(), e);
-            return false; // Or throw specific exception
+            registrationCache.invalidate(request.getFlowId());
+            log.error("Passkey registration failed for user with handle: {}. FlowId: {}. Reason: {}",
+                    creationOptions.getUser().getDisplayName(), request.getFlowId(), e.getMessage(), e);
+            return false;
         }
     }
 
@@ -249,99 +250,89 @@ public class PasskeyServiceImpl implements PasskeyService {
         String flowId = generateFlowId();
         AssertionRequest assertionRequest = relyingParty.startAssertion(options);
         authenticationCache.put(flowId, assertionRequest);
-        log.info("Start Assertion Request: {}", assertionRequest);
+        // log.info("Start Assertion Request: {}", assertionRequest); // assertionRequest contains sensitive info
 
-        PublicKeyCredentialRequestOptions credentialCreationOptions = assertionRequest.getPublicKeyCredentialRequestOptions();
-
-        log.info("Started passkey authentication, flowId: {}. For user (if provided): {}", flowId, request.getEmail());
-        return new PasskeyAuthenticationStartResponseDto(flowId, credentialCreationOptions);
+        PublicKeyCredentialRequestOptions requestOptions = assertionRequest.getPublicKeyCredentialRequestOptions();
+        String userHint = request.getEmail() != null && !request.getEmail().isBlank() ? "email hint provided" : "discoverable credential";
+        log.info("Started passkey authentication. FlowId: {}. User hint: {}", flowId, userHint);
+        return new PasskeyAuthenticationStartResponseDto(flowId, requestOptions);
     }
 
     @Override
     @Transactional
     public PasskeyAuthenticationResponseDto finishAuthentication(PasskeyAuthenticationFinishRequestDto request) {
-        log.info("finish authentication");
-        log.info("flow id: {}", request.getFlowId());
-        log.info("credential: {}", request.getCredential());
+        log.info("Attempting to finish passkey authentication for flowId: {}", request.getFlowId());
 
-        request.setCredential(request.getCredential());
-        AssertionRequest requestOptions = authenticationCache.getIfPresent(request.getFlowId());
-        log.info("Finish Assertion Request: {}", requestOptions);
-        if (requestOptions == null) {
+        AssertionRequest assertionRequestOptions = authenticationCache.getIfPresent(request.getFlowId());
+        if (assertionRequestOptions == null) {
             log.warn("Passkey authentication flow ID {} not found or expired.", request.getFlowId());
             return new PasskeyAuthenticationResponseDto(false, "Authentication flow expired or invalid.");
         }
-        // Do NOT invalidate from cache immediately for the same reasons as registration
 
         try {
-            log.info("finish authentication assertion result");
+            log.debug("Calling relyingParty.finishAssertion for flowId: {}", request.getFlowId());
             AssertionResult assertionResult = relyingParty.finishAssertion(FinishAssertionOptions.builder()
-                    .request(requestOptions)
+                    .request(assertionRequestOptions)
                     .response(request.getCredential())
                     .build());
 
             if (assertionResult.isSuccess()) {
-                log.info("finish authentication assertion result success");
-                // IMPORTANT: Update the signature count in the database
-                // The JpaCredentialRepository's updateSignatureCount method will be called by the library if configured correctly.
-                // If not, or for belt-and-suspenders, ensure it's done:
-                log.info("finish authentication assertion result findByCredentialId");
-                log.info("credential: {}", assertionResult.getCredentialId());
-                log.info("credential base 64: {}", assertionResult.getCredentialId().getBase64Url());
+                log.info("Passkey assertion successful for user handle: {}, credentialId (first 8 bytes): {}",
+                        assertionResult.getUserHandle().getBase64Url(), Base64.getEncoder().encodeToString(Arrays.copyOf(assertionResult.getCredentialId().getBytes(), 8)));
+
                 Optional<PasskeySummary> optionalPasskeySummary = passkeyCredentialRepository.findPasskeyByCredentialId(assertionResult.getCredentialId().getBytes());
 
                 if(optionalPasskeySummary.isPresent()){
                     PasskeySummary cred = optionalPasskeySummary.get();
                     cred.setSignatureCount(assertionResult.getSignatureCount());
                     cred.setLastUsedAt(new Date());
-                    log.info("saving passkey credential");
+                    log.debug("Updating signature count and last used time for credentialId (first 8 bytes): {}", Base64.getEncoder().encodeToString(Arrays.copyOf(cred.getCredentialId(), 8)));
                     passkeyCredentialRepository.updatePasskeySummary(cred);
                 } else {
-                     log.error("Passkey credential {} not found during finishAuthentication for signature count update.", assertionResult.getCredentialId().getBase64Url());
+                     log.error("Passkey credential (first 8 bytes: {}) not found for signature count update. User handle from assertion: {}",
+                             Base64.getEncoder().encodeToString(Arrays.copyOf(assertionResult.getCredentialId().getBytes(), 8)), assertionResult.getUserHandle().getBase64Url());
                 }
 
-                log.info("finish authentication assertion result UsersEntity");
-                log.info("assertion result username: {}", assertionResult.getUsername());
+                log.debug("Attempting to find user by user handle from assertion: {}", assertionResult.getUserHandle().getBase64Url());
+                // assertionResult.getUsername() is the email. Use userHandle to find user if possible, or log username if it's not email.
+                // For now, we retrieve by email (username from assertion) then log the system username.
                 UsersEntity user = userRepository.findUserByEmail(assertionResult.getUsername()).orElseThrow(
-                        () -> new UserNotFoundException("user not found by email for passkey")
+                        () -> {
+                            log.error("User (associated with user handle {}) not found in database using email from assertion. FlowId: {}",
+                                    assertionResult.getUserHandle().getBase64Url(), request.getFlowId());
+                            return new UserNotFoundException("Authenticated user not found.");
+                        }
                 );
-                if (user == null) {
-                    // This can happen if the username from assertion doesn't match any user.
-                    // Or if the user was deleted between start and finish.
-                    log.error("User {} from passkey assertion not found in database.", assertionResult.getUsername());
-                    authenticationCache.invalidate(request.getFlowId());
-                    return new PasskeyAuthenticationResponseDto(false, "Authenticated user not found.");
-                }
+                log.info("User {} (associated with user handle {}) found. Updating last login date.", user.getUsername(), assertionResult.getUserHandle().getBase64Url());
 
-                // Update user's last login date
                 user.setLastLoginDateDisplay(new Date());
                 user.setLastLoginDate(new Date());
-                log.info("saving user");
                 user = userRepository.save(user);
+                log.debug("User {} last login date updated.", user.getUsername());
 
                 UserPrincipal userPrincipal = new UserPrincipal(user);
-
-                // Manually create an Authentication object for the SecurityContext
-                // This mimics what Spring Security would do for a password login
-                // Note: For passkeys, authorities are usually derived from the user's existing roles, not the passkey itself.
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                        userPrincipal, null, userPrincipal.getAuthorities());
-
                 String jwtToken = jwtTokenUtil.createToken(userPrincipal);
                 authenticationCache.invalidate(request.getFlowId());
 
-                UsersEntity passkeyUser = userRepository.findUserByEmail(user.getEmail()).orElseThrow(() -> new UserNotFoundException("User not located by email for passkey"));
-                log.info("Successfully authenticated user {} with passkey credentialId: {}", user.getUsername(), assertionResult.getCredentialId().getBase64Url());
+                UsersEntity passkeyUser = userRepository.findUserByEmail(user.getEmail()).orElseThrow(() -> new UserNotFoundException("User not located by email for passkey post-authentication."));
+                log.info("Successfully authenticated user {} with passkey. FlowId: {}", user.getUsername(), request.getFlowId());
                 return new PasskeyAuthenticationResponseDto(true, "Authentication successful", jwtToken, passkeyUser);
             } else {
-                log.info("finish authentication assertion result fail");
                 authenticationCache.invalidate(request.getFlowId());
-                log.warn("Passkey assertion failed for credentialId: {}. Username from assertion: {}", request.getCredential().getId().getBase64Url(), assertionResult.getUsername());
+                log.warn("Passkey assertion failed for flowId: {}. User handle from assertion (if available): {}",
+                        request.getFlowId(), assertionResult.getUserHandle() != null ? assertionResult.getUserHandle().getBase64Url() : "N/A");
                 return new PasskeyAuthenticationResponseDto(false, "Authentication failed.");
             }
         } catch (AssertionFailedException | UserNotFoundException e) {
             authenticationCache.invalidate(request.getFlowId());
-            log.error("Passkey assertion failed. Credential ID: {}. Message: {}", request.getCredential().getId().getBase64Url(), e.getMessage(), e);
+            String credentialIdExtract = "N/A";
+            if (request.getCredential() != null && request.getCredential().getId() != null) {
+                try {
+                    credentialIdExtract = Base64.getEncoder().encodeToString(Arrays.copyOf(request.getCredential().getId().getBytes(), 8));
+                } catch (Exception ignored) {}
+            }
+            log.error("Passkey assertion failed for flowId: {}. Credential ID (first 8 bytes, if available): {}. Message: {}",
+                    request.getFlowId(), credentialIdExtract, e.getMessage(), e);
             return new PasskeyAuthenticationResponseDto(false, "Authentication failed: " + e.getMessage());
         }
     }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/PasskeyServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/PasskeyServiceImpl.java
@@ -98,7 +98,7 @@ public class PasskeyServiceImpl implements PasskeyService {
         if (optionalUsersEntity.isPresent()) {
             user = optionalUsersEntity.get();
         } else {
-            // consider adding this part after user email is validated and user ownership of email is confirmed.
+// consider adding this part after user email is validated and user ownership of email is confirmed.
 //            log.info("creating new user");
 //            UserRegisterRequest userRegisterRequest = new UserRegisterRequest();
 //            userRegisterRequest.setEmail(request.getEmail());
@@ -135,7 +135,7 @@ public class PasskeyServiceImpl implements PasskeyService {
         String flowId = generateFlowId();
         registrationCache.put(flowId, credentialCreationOptions);
         log.info("Registration cache populated for flowId: {}", flowId);
-        log.info("Started passkey registration process for user with handle: {}, flowId: {}", user.getUserHandle(), flowId);
+        log.info("Started passkey registration process for user with flowId: {}", flowId);
         return new PasskeyRegistrationStartResponseDto(flowId, credentialCreationOptions);
     }
 
@@ -172,7 +172,6 @@ public class PasskeyServiceImpl implements PasskeyService {
             PasskeyCredentialEntity passkeyCredential = new PasskeyCredentialEntity();
             passkeyCredential.setUser(user);
             passkeyCredential.setCredentialId(registrationResult.getKeyId().getId().getBytes());
-            // log.info("REGISTRATION RESULT PUBLIC KEY COSE: {}", registrationResult.getPublicKeyCose().getBytes()); // Sensitive
             byte[] pkBytes = registrationResult.getPublicKeyCose().getBytes();
             passkeyCredential.setPublicKeyCose(pkBytes);
 
@@ -250,7 +249,6 @@ public class PasskeyServiceImpl implements PasskeyService {
         String flowId = generateFlowId();
         AssertionRequest assertionRequest = relyingParty.startAssertion(options);
         authenticationCache.put(flowId, assertionRequest);
-        // log.info("Start Assertion Request: {}", assertionRequest); // assertionRequest contains sensitive info
 
         PublicKeyCredentialRequestOptions requestOptions = assertionRequest.getPublicKeyCredentialRequestOptions();
         String userHint = request.getEmail() != null && !request.getEmail().isBlank() ? "email hint provided" : "discoverable credential";


### PR DESCRIPTION
Further refined logging in the n1netails-api passkey implementation to completely remove user email addresses from INFO, WARN, ERROR, and relevant DEBUG logs.

Key changes:
- Modified PasskeyController.java, PasskeyServiceImpl.java, and YubicoCredentialRepositoryImpl.java.
- Replaced direct email logging with generic messages (e.g., "user with provided hint"), internal user handles, or application usernames (`user.getUsername()`).
- Ensured that even parameters named 'username' which actually held email addresses (common in Yubico library usage) are no longer logged directly.

This builds upon previous log sanitization efforts to specifically address and remove all instances of email PII in logs.