### PR TITLE
feat: Make settings page responsive

### DIFF
--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
@@ -10,183 +10,196 @@
 
     <nz-content>
       <div class="inner-content">
-
-        <div class="settings-container">
+        <nz-row class="settings-container" [nzGutter]="[16, 16]">
           <!-- N1ne Token Management Card -->
-          <nz-card nzTitle="N1ne Token Manager" class="tails-primary-color" [nzBordered]="false">
-            <div *ngIf="isLoading" class="loading-indicator">Loading tokens...</div>
-            <div *ngIf="errorMessage" [class.bind]="'error-message'" style="color: red; margin-bottom: 10px;">{{ errorMessage }}</div>
+          <nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24">
+            <nz-card nzTitle="N1ne Token Manager" class="tails-primary-color" [nzBordered]="false">
+              <div *ngIf="isLoading" class="loading-indicator">Loading tokens...</div>
+              <div *ngIf="errorMessage" [class.bind]="'error-message'" style="color: red; margin-bottom: 10px;">{{ errorMessage }}</div>
 
-            <!-- Create Token Form -->
-            <h3>Create New Token</h3>
-            <form #tokenForm="ngForm" (ngSubmit)="createToken()" nz-form>
-              <nz-form-item>
-                <nz-form-label [nzSm]="6" [nzXs]="24" nzFor="tokenName" nzRequired>Token Name</nz-form-label>
-                <nz-form-control [nzSm]="14" [nzXs]="24">
-                  <input nz-input type="text" id="tokenName" name="name" [(ngModel)]="newTokenRequestForm.name" placeholder="Enter a name for the token" required #name="ngModel">
-                  <div *ngIf="name.invalid && (name.dirty || name.touched)" class="error-text">
-                    Token name is required.
-                  </div>
-                </nz-form-control>
-              </nz-form-item>
-              <nz-form-item>
-                <nz-form-label [nzSm]="6" [nzXs]="24" nzFor="organization" nzRequired>Organization</nz-form-label>
-                <nz-form-control [nzSm]="14" [nzXs]="24">
-                  <nz-select
-                    id="organization"
-                    name="organization"
-                    [(ngModel)]="newTokenRequestForm.organizationId"
-                    nzPlaceHolder="Select organization"
-                    required
-                  >
-                    <nz-option
-                      *ngFor="let org of organizations"
-                      [nzValue]="org.id"
-                      [nzLabel]="org.name"
-                    ></nz-option>
-                  </nz-select>
-                </nz-form-control>
-              </nz-form-item>
-              <nz-form-item>
-                <nz-form-label [nzSm]="6" [nzXs]="24" nzFor="tokenExpiresAt">Expiration Date (Optional)</nz-form-label>
-                <nz-form-control [nzSm]="14" [nzXs]="24">
-                  <input nz-input type="datetime-local" id="tokenExpiresAt" name="expiresAt" [(ngModel)]="newTokenRequestForm.expiresAt">
-                </nz-form-control>
-              </nz-form-item>
-              <nz-form-item>
-                <nz-form-control [nzSm]="14" [nzXs]="24" [nzOffset]="6">
-                  <button nz-button nzType="primary" type="submit" [disabled]="!tokenForm.form.valid || isLoading">+ Create Token</button>
-                </nz-form-control>
-              </nz-form-item>
-            </form>
-
-            <nz-divider></nz-divider>
-
-            <!-- Display Tokens Table -->
-            <h3>Active Tokens</h3>
-            <nz-table #activeTokensTable [nzData]="tokens" [nzLoading]="isLoading" nzSize="small">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>ID</th>
-                  <th>Token Value</th>
-                  <th>Created At</th>
-                  <th>Expires At</th>
-                  <th>Last Used At</th>
-                  <th>Status</th>
-                  <th>User</th>
-                  <th>Org</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr *ngFor="let token of tokens; let i = index">
-                  <td>{{ token.name }}</td>
-                  <td>{{ token.id }}</td>
-                  <td>
-                    <div class="token-value-cell">
-                      <input
-                        nz-input
-                        [type]="showTokenIndex === i ? 'text' : 'password'"
-                        [value]="token.token"
-                        readonly
-                        style="width: 140px; margin-right: 4px;"
-                        (click)="toggleShowToken(i)"
-                      />
-                      <button
-                        nz-button
-                        nzType="link"
-                        nzSize="small"
-                        (click)="toggleShowToken(i)"
-                        [attr.aria-label]="showTokenIndex === i ? 'Hide' : 'Show'"
-                        style="padding: 0 4px;"
-                      >
-                        <span *ngIf="showTokenIndex !== i" nz-icon nzType="eye-invisible"></span>
-                        <span *ngIf="showTokenIndex === i" nz-icon nzType="eye"></span>
-                      </button>
-                      <button
-                        nz-button
-                        nzType="link"
-                        nzSize="small"
-                        (click)="copyToken(token.token)"
-                        aria-label="Copy"
-                        style="padding: 0 4px;"
-                      >
-                        <span nz-icon nzType="copy"></span>
-                      </button>
+              <!-- Create Token Form -->
+              <h3>Create New Token</h3>
+              <form #tokenForm="ngForm" (ngSubmit)="createToken()" nz-form>
+                <nz-form-item>
+                  <nz-form-label [nzSm]="6" [nzXs]="24" nzFor="tokenName" nzRequired>Token Name</nz-form-label>
+                  <nz-form-control [nzSm]="14" [nzXs]="24">
+                    <input nz-input type="text" id="tokenName" name="name" [(ngModel)]="newTokenRequestForm.name" placeholder="Enter a name for the token" required #name="ngModel">
+                    <div *ngIf="name.invalid && (name.dirty || name.touched)" class="error-text">
+                      Token name is required.
                     </div>
-                  </td>
-                  <td>{{ token.createdAt | date:'short' }}</td>
-                  <td>{{ token.expiresAt ? (token.expiresAt | date:'short') : 'Never' }}</td>
-                  <td>{{ token.lastUsedAt ? (token.lastUsedAt | date:'short') : 'Never' }}</td>
-                  <td>
-                    <span *ngIf="token.revoked" style="color: red;">Revoked</span>
-                    <span *ngIf="!token.revoked" style="color: green;">Active</span>
-                  </td>
-                  <td>{{ user.username }}</td>
-                  <!-- TODO GET ORGANIATION INFO BY ORGANIZATION ID (DISPLAY ORGANIZATON NAME HERE)-->
-                  <td>{{ token.organizationId }}</td>
-                  <td>
-                    <button nz-button nzType="default" (click)="revokeToken(token)" *ngIf="!token.revoked" [disabled]="isLoading" nzSize="small" style="margin-right: 5px;">Revoke</button>
-                    <button nz-button nzType="default" (click)="enableToken(token)" *ngIf="token.revoked" [disabled]="isLoading" nzSize="small" style="margin-right: 5px;">Enable</button>
-                    <button nz-button nzType="primary" nzDanger (click)="deleteToken(token.id)" [disabled]="isLoading" nzSize="small">Delete</button>
-                  </td>
-                </tr>
-                <tr *ngIf="!isLoading && tokens.length === 0">
-                  <td colspan="9" style="text-align: center;">No tokens found.</td>
-                </tr>
-              </tbody>
-            </nz-table>
-          </nz-card>
+                  </nz-form-control>
+                </nz-form-item>
+                <nz-form-item>
+                  <nz-form-label [nzSm]="6" [nzXs]="24" nzFor="organization" nzRequired>Organization</nz-form-label>
+                  <nz-form-control [nzSm]="14" [nzXs]="24">
+                    <nz-select
+                      id="organization"
+                      name="organization"
+                      [(ngModel)]="newTokenRequestForm.organizationId"
+                      nzPlaceHolder="Select organization"
+                      required
+                    >
+                      <nz-option
+                        *ngFor="let org of organizations"
+                        [nzValue]="org.id"
+                        [nzLabel]="org.name"
+                      ></nz-option>
+                    </nz-select>
+                  </nz-form-control>
+                </nz-form-item>
+                <nz-form-item>
+                  <nz-form-label [nzSm]="6" [nzXs]="24" nzFor="tokenExpiresAt">Expiration Date (Optional)</nz-form-label>
+                  <nz-form-control [nzSm]="14" [nzXs]="24">
+                    <input nz-input type="datetime-local" id="tokenExpiresAt" name="expiresAt" [(ngModel)]="newTokenRequestForm.expiresAt">
+                  </nz-form-control>
+                </nz-form-item>
+                <nz-form-item>
+                  <nz-form-control [nzSm]="14" [nzXs]="24" [nzOffset]="6">
+                    <button nz-button nzType="primary" type="submit" [disabled]="!tokenForm.form.valid || isLoading" class="create-token-btn">+ Create Token</button>
+                  </nz-form-control>
+                </nz-form-item>
+              </form>
+
+              <nz-divider></nz-divider>
+
+              <!-- Display Tokens Table -->
+              <h3>Active Tokens</h3>
+              <div class="table-responsive-wrapper">
+                <nz-table #activeTokensTable [nzData]="tokens" [nzLoading]="isLoading" nzSize="small">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>ID</th>
+                      <th>Token Value</th>
+                      <th>Created At</th>
+                      <th>Expires At</th>
+                      <th>Last Used At</th>
+                      <th>Status</th>
+                      <th>User</th>
+                      <th>Org</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr *ngFor="let token of tokens; let i = index">
+                      <td>{{ token.name }}</td>
+                      <td>{{ token.id }}</td>
+                      <td>
+                        <div class="token-value-cell">
+                          <input
+                            nz-input
+                            [type]="showTokenIndex === i ? 'text' : 'password'"
+                            [value]="token.token"
+                            readonly
+                            style="width: 140px; margin-right: 4px;"
+                            (click)="toggleShowToken(i)"
+                          />
+                          <button
+                            nz-button
+                            nzType="link"
+                            nzSize="small"
+                            (click)="toggleShowToken(i)"
+                            [attr.aria-label]="showTokenIndex === i ? 'Hide' : 'Show'"
+                            style="padding: 0 4px;"
+                          >
+                            <span *ngIf="showTokenIndex !== i" nz-icon nzType="eye-invisible"></span>
+                            <span *ngIf="showTokenIndex === i" nz-icon nzType="eye"></span>
+                          </button>
+                          <button
+                            nz-button
+                            nzType="link"
+                            nzSize="small"
+                            (click)="copyToken(token.token)"
+                            aria-label="Copy"
+                            style="padding: 0 4px;"
+                          >
+                            <span nz-icon nzType="copy"></span>
+                          </button>
+                        </div>
+                      </td>
+                      <td>{{ token.createdAt | date:'short' }}</td>
+                      <td>{{ token.expiresAt ? (token.expiresAt | date:'short') : 'Never' }}</td>
+                      <td>{{ token.lastUsedAt ? (token.lastUsedAt | date:'short') : 'Never' }}</td>
+                      <td>
+                        <span *ngIf="token.revoked" style="color: red;">Revoked</span>
+                        <span *ngIf="!token.revoked" style="color: green;">Active</span>
+                      </td>
+                      <td>{{ user.username }}</td>
+                      <!-- TODO GET ORGANIATION INFO BY ORGANIZATION ID (DISPLAY ORGANIZATON NAME HERE)-->
+                      <td>{{ token.organizationId }}</td>
+                      <td>
+                        <button nz-button nzType="default" (click)="revokeToken(token)" *ngIf="!token.revoked" [disabled]="isLoading" nzSize="small" style="margin-right: 5px;">Revoke</button>
+                        <button nz-button nzType="default" (click)="enableToken(token)" *ngIf="token.revoked" [disabled]="isLoading" nzSize="small" style="margin-right: 5px;">Enable</button>
+                        <button nz-button nzType="primary" nzDanger (click)="deleteToken(token.id)" [disabled]="isLoading" nzSize="small">Delete</button>
+                      </td>
+                    </tr>
+                    <tr *ngIf="!isLoading && tokens.length === 0">
+                      <td colspan="9" style="text-align: center;">No tokens found.</td>
+                    </tr>
+                  </tbody>
+                </nz-table>
+              </div>
+            </nz-card>
+          </nz-col>
 
           <!-- TODO ADD THIS FEATURE IN LATER -->
           <!-- provide users with options to selete their perferred alert types -->
-          <!-- <nz-card nzTitle="Preferred Alert Types" class="tails-primary-color" [nzBordered]="false">
-            <form nz-form (ngSubmit)="onSavePreferredTypes()" #preferredTypesForm="ngForm">
-              <nz-checkbox-group [(ngModel)]="preferredAlertTypes" [nzOptions]="alertTypeOptions"
-                name="preferredAlertTypes"></nz-checkbox-group>
-              <button nz-button nzType="primary" type="submit" style="margin-top: 16px;">Save Preferences</button>
-            </form>
-          </nz-card> -->
+          <!-- <nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24">
+            <nz-card nzTitle="Preferred Alert Types" class="tails-primary-color" [nzBordered]="false">
+              <form nz-form (ngSubmit)="onSavePreferredTypes()" #preferredTypesForm="ngForm">
+                <nz-checkbox-group [(ngModel)]="preferredAlertTypes" [nzOptions]="alertTypeOptions"
+                  name="preferredAlertTypes"></nz-checkbox-group>
+                <button nz-button nzType="primary" type="submit" style="margin-top: 16px;">Save Preferences</button>
+              </form>
+            </nz-card>
+          </nz-col> -->
 
-          <nz-card nzTitle="Alert Levels, Statuses, and Types" class="tails-primary-color" [nzBordered]="false">
-            <div class="alert-management">
-              <div class="alert-list">
-                <h4>Tail Levels</h4>
-                <ul>
-                  <li *ngFor="let level of tailLevels">
-                    {{ level.name }}
-                    <button *ngIf="level.deletable" nz-button nzType="link" nzDanger (click)="removeAlertLevel(level.name)">Remove</button>
-                  </li>
-                </ul>
-                <input nz-input [(ngModel)]="newTailLevel" name="newTailLevel" placeholder="Add new level" />
-                <button nz-button nzType="default" (click)="addAlertLevel()">+</button>
+          <nz-col [nzXs]="24" [nzSm]="24" [nzMd]="24" [nzLg]="24" [nzXl]="24">
+            <nz-card nzTitle="Alert Levels, Statuses, and Types" class="tails-primary-color" [nzBordered]="false">
+              <div class="alert-management">
+                <div class="alert-list">
+                  <h4>Tail Levels</h4>
+                  <ul>
+                    <li *ngFor="let level of tailLevels">
+                      {{ level.name }}
+                      <button *ngIf="level.deletable" nz-button nzType="link" nzDanger (click)="removeAlertLevel(level.name)">Remove</button>
+                    </li>
+                  </ul>
+                  <div class="alert-add-form">
+                    <input nz-input [(ngModel)]="newTailLevel" name="newTailLevel" placeholder="Add new level" class="alert-input"/>
+                    <button nz-button nzType="default" (click)="addAlertLevel()" class="alert-add-btn">+</button>
+                  </div>
+                </div>
+                <div class="alert-list">
+                  <h4>Tail Statuses</h4>
+                  <ul>
+                    <li *ngFor="let status of tailStatuses">
+                      {{ status.name }}
+                      <button *ngIf="status.deletable" nz-button nzType="link" nzDanger (click)="removeAlertStatus(status.name)">Remove</button>
+                    </li>
+                  </ul>
+                  <div class="alert-add-form">
+                    <input nz-input [(ngModel)]="newTailStatus" name="newTailStatus" placeholder="Add new status" class="alert-input"/>
+                    <button nz-button nzType="default" (click)="addAlertStatus()" class="alert-add-btn">+</button>
+                  </div>
+                </div>
+                <div class="alert-list">
+                  <h4>Tail Types</h4>
+                  <ul>
+                    <li *ngFor="let type of tailTypes">
+                      {{ type.name }}
+                      <button *ngIf="type.deletable" nz-button nzType="link" nzDanger (click)="removeAlertType(type.name)">Remove</button>
+                    </li>
+                  </ul>
+                  <div class="alert-add-form">
+                    <input nz-input [(ngModel)]="newTailType" name="newTailType" placeholder="Add new type" class="alert-input"/>
+                    <button nz-button nzType="default" (click)="addAlertType()" class="alert-add-btn">+</button>
+                  </div>
+                </div>
               </div>
-              <div class="alert-list">
-                <h4>Tail Statuses</h4>
-                <ul>
-                  <li *ngFor="let status of tailStatuses">
-                    {{ status.name }}
-                    <button *ngIf="status.deletable" nz-button nzType="link" nzDanger (click)="removeAlertStatus(status.name)">Remove</button>
-                  </li>
-                </ul>
-                <input nz-input [(ngModel)]="newTailStatus" name="newTailStatus" placeholder="Add new status" />
-                <button nz-button nzType="default" (click)="addAlertStatus()">+</button>
-              </div>
-              <div class="alert-list">
-                <h4>Tail Types</h4>
-                <ul>
-                  <li *ngFor="let type of tailTypes">
-                    {{ type.name }}
-                    <button *ngIf="type.deletable" nz-button nzType="link" nzDanger (click)="removeAlertType(type.name)">Remove</button>
-                  </li>
-                </ul>
-                <input nz-input [(ngModel)]="newTailType" name="newTailType" placeholder="Add new type" />
-                <button nz-button nzType="default" (click)="addAlertType()">+</button>
-              </div>
-            </div>
-          </nz-card>
-        </div>
+            </nz-card>
+          </nz-col>
+        </nz-row>
       </div>
     </nz-content>
   </nz-layout>

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
@@ -54,7 +54,7 @@
                   </nz-form-control>
                 </nz-form-item>
                 <nz-form-item>
-                  <nz-form-control [nzSm]="14" [nzXs]="24" [nzOffset]="6">
+                  <nz-form-control [nzSm]="14" [nzXs]="24">
                     <button nz-button nzType="primary" type="submit" [disabled]="!tokenForm.form.valid || isLoading" class="create-token-btn">+ Create Token</button>
                   </nz-form-control>
                 </nz-form-item>

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
@@ -15,17 +15,17 @@ nz-header {
 }
 
 // General button styling (if not already global or overridden by Ant components)
-// button[nz-button] {
-//   // background: @primary-color; // Base styles from variables.less or Ant default
-//   // color: #fff;
-//   // border: none;
-//   // border-radius: 4px;
-//   // font-weight: 600;
-//   // &:hover, &:focus {
-//   //   background: @secondary-color;
-//   //   color: #fff;
-//   // }
-// }
+button[nz-button] {
+  background: @primary-color; // Base styles from variables.less or Ant default
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-weight: 600;
+  &:hover, &:focus {
+    background: @secondary-color;
+    color: #fff;
+  }
+}
 
 // Create Token Button specific styling
 .create-token-btn {
@@ -49,12 +49,7 @@ nz-header {
 }
 
 
-.token-form, // Assuming this class is still used on the form element
-.password-form { // If there's a password form elsewhere or planned
-  // display: flex; // Default Ant form items handle this well with nz-row/nz-col
-  // flex-direction: row;
-  // align-items: flex-end;
-  // gap: 16px;
+.token-form {
   margin-bottom: 24px;
 }
 
@@ -103,7 +98,8 @@ nz-header {
       }
 
       .alert-add-btn { // Class added in HTML
-        // Potentially adjust padding or min-width if needed
+        padding-left: 13px;
+        padding-right: 13px;
       }
 
       @media (max-width: @screen-xs-max) { // Very small screens
@@ -117,29 +113,29 @@ nz-header {
 }
 
 // General input styling (ensure it doesn't conflict with Ant's defaults too much)
-// input[nz-input], .ant-input, .ant-input-affix-wrapper {
-//   width: 100%; // Default to full width, can be constrained by parent
-//   min-width: 180px; // A sensible minimum
-//   // background: #23272b !important; // Prefer not to use !important unless necessary
-//   // color: #fff !important;
-//   // border: 1px solid #444 !important;
-//   // border-radius: 6px !important;
-//   // font-size: 14px;
-//   // padding: 8px 12px !important;
-//   // box-shadow: none !important;
-//   // outline: none !important;
-//   // transition: border 0.2s, background 0.2s;
+input[nz-input], .ant-input, .ant-input-affix-wrapper {
+  width: 100%; // Default to full width, can be constrained by parent
+  min-width: 180px; // A sensible minimum
+  background: #23272b !important; // Prefer not to use !important unless necessary
+  color: #fff !important;
+  border: 1px solid #444 !important;
+  border-radius: 6px !important;
+  font-size: 14px;
+  padding: 8px 12px !important;
+  box-shadow: none !important;
+  outline: none !important;
+  transition: border 0.2s, background 0.2s;
 
-//   // &::placeholder {
-//   //   color: #b3b3b3 !important;
-//   //   opacity: 1;
-//   // }
+  &::placeholder {
+    color: #b3b3b3 !important;
+    opacity: 1;
+  }
 
-//   // &:focus {
-//   //   border: 1.5px solid @primary-color !important;
-//   //   background: #181a1b !important;
-//   // }
-// }
+  &:focus {
+    border: 1.5px solid @primary-color !important;
+    background: #181a1b !important;
+  }
+}
 
 .token-value-cell {
   display: flex;

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
@@ -7,24 +7,55 @@ nz-header {
 }
 
 .settings-container {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  // display: flex; // Handled by nz-row
+  // flex-direction: column; // Handled by nz-row/nz-col
+  // gap: 8px; // Handled by nzGutter
   padding: 8px 0;
   min-height: 100vh;
 }
 
-.token-form,
-.password-form {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-end;
-  gap: 16px;
-  margin-bottom: 24px;
+// General button styling (if not already global or overridden by Ant components)
+// button[nz-button] {
+//   // background: @primary-color; // Base styles from variables.less or Ant default
+//   // color: #fff;
+//   // border: none;
+//   // border-radius: 4px;
+//   // font-weight: 600;
+//   // &:hover, &:focus {
+//   //   background: @secondary-color;
+//   //   color: #fff;
+//   // }
+// }
+
+// Create Token Button specific styling
+.create-token-btn {
+  @media (max-width: @screen-sm-max) {
+    width: 100%;
+  }
 }
 
-.token-table {
-  margin-top: 16px;
+// Token Table Responsive Wrapper
+.table-responsive-wrapper {
+  @media (max-width: @screen-md-max) { // Or @screen-sm-max depending on when it breaks
+    overflow-x: auto;
+    display: block; // Important for overflow to work on table
+    width: 100%;
+  }
+
+  nz-table {
+    // Ensure table itself doesn't try to shrink unnaturally
+    min-width: 800px; // Adjust based on your table's actual minimum comfortable width
+  }
+}
+
+
+.token-form, // Assuming this class is still used on the form element
+.password-form { // If there's a password form elsewhere or planned
+  // display: flex; // Default Ant form items handle this well with nz-row/nz-col
+  // flex-direction: row;
+  // align-items: flex-end;
+  // gap: 16px;
+  margin-bottom: 24px;
 }
 
 .alert-management {
@@ -34,8 +65,9 @@ nz-header {
   margin-top: 16px;
 
   .alert-list {
-    min-width: 200px;
-    flex: 1;
+    min-width: 200px; // Keeps a minimum width before wrapping
+    flex: 1; // Allows lists to grow and fill space
+
     h4 {
       color: @primary-color;
       margin-bottom: 8px;
@@ -53,64 +85,77 @@ nz-header {
         border-radius: 4px;
         margin-bottom: 4px;
         color: #fff;
+
+        button[nz-button][nzType="link"] { // More specific selector for remove buttons
+          padding: 0 4px; // Adjust padding for link buttons if needed
+          min-width: auto; // Override default min-width for small link buttons
+        }
       }
     }
-    input[nz-input] {
-      width: 70%;
-      margin-right: 8px;
-      background: #181a1b;
-      color: #fff;
-      border: 1px solid #444;
-    }
-    button[nz-button] {
-      background: @primary-color;
-      color: #fff;
-      border: none;
-      &:hover {
-        background: @secondary-color;
+
+    .alert-add-form {
+      display: flex;
+      gap: 8px; // Space between input and button
+
+      .alert-input { // Class added in HTML
+        flex-grow: 1; // Input takes available space
+        // width: auto; // Override fixed width if previously set
+      }
+
+      .alert-add-btn { // Class added in HTML
+        // Potentially adjust padding or min-width if needed
+      }
+
+      @media (max-width: @screen-xs-max) { // Very small screens
+        flex-direction: column; // Stack input and button
+        .alert-input, .alert-add-btn {
+          width: 100%; // Both take full width when stacked
+        }
       }
     }
   }
 }
 
-button[nz-button] {
-  background: @primary-color;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  font-weight: 600;
-  &:hover, &:focus {
-    background: @secondary-color;
-    color: #fff;
-  }
-}
+// General input styling (ensure it doesn't conflict with Ant's defaults too much)
+// input[nz-input], .ant-input, .ant-input-affix-wrapper {
+//   width: 100%; // Default to full width, can be constrained by parent
+//   min-width: 180px; // A sensible minimum
+//   // background: #23272b !important; // Prefer not to use !important unless necessary
+//   // color: #fff !important;
+//   // border: 1px solid #444 !important;
+//   // border-radius: 6px !important;
+//   // font-size: 14px;
+//   // padding: 8px 12px !important;
+//   // box-shadow: none !important;
+//   // outline: none !important;
+//   // transition: border 0.2s, background 0.2s;
 
-input[nz-input], .ant-input, .ant-input-affix-wrapper {
-  width: 100%;
-  min-width: 180px;
-  background: #23272b !important;
-  color: #fff !important;
-  border: 1px solid #444 !important;
-  border-radius: 6px !important;
-  font-size: 14px;
-  padding: 8px 12px !important;
-  box-shadow: none !important;
-  outline: none !important;
-  transition: border 0.2s, background 0.2s;
+//   // &::placeholder {
+//   //   color: #b3b3b3 !important;
+//   //   opacity: 1;
+//   // }
 
-  &::placeholder {
-    color: #b3b3b3 !important;
-    opacity: 1;
-  }
-
-  &:focus {
-    border: 1.5px solid @primary-color !important;
-    background: #181a1b !important;
-  }
-}
+//   // &:focus {
+//   //   border: 1.5px solid @primary-color !important;
+//   //   background: #181a1b !important;
+//   // }
+// }
 
 .token-value-cell {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 2px; // Small gap between input and buttons in token cell
+  // Ensure child elements don't cause overflow if possible
+  input[nz-input] {
+    flex-shrink: 1; // Allow input to shrink if space is tight
+    min-width: 100px; // Or a value that makes sense for this specific input
+  }
+}
+
+// Ensure form labels are responsive if not already handled by nz-form-label attributes
+.ant-form-item-label {
+  @media (max-width: @screen-sm-max) {
+    text-align: left !important; // Align labels to the left on small screens
+    padding-bottom: 4px; // Add some space below the label
+  }
 }

--- a/n1netails-ui/src/main/typescript/src/variables.less
+++ b/n1netails-ui/src/main/typescript/src/variables.less
@@ -2,5 +2,6 @@
 @secondary-color: #F38A3F;
 @info-color: #59C7FF;
 
-@screen-sm-max: 767px; // Max width before medium screens
-@screen-md-max: 991px; // Max width before large screens
+@screen-xs-max: 575px;
+@screen-sm-max: 767px;
+@screen-md-max: 991px;


### PR DESCRIPTION
Applied responsive design principles to the settings page (n1netails-ui/src/main/typescript/src/app/pages/settings) to ensure it adapts to various screen sizes, from mobile to desktop.

Key changes include:
- Integrated Ant Design's grid system (nz-row, nz-col) for overall layout structure.
- Made the "Active Tokens" table horizontally scrollable on smaller screens to prevent content overflow and maintain readability.
- Styled form buttons (e.g., "Create Token", "Add Alert Type") to be full-width on small screens for better usability.
- Adapted the "Alert Levels, Statuses, and Types" management section so that input fields and buttons stack vertically on very small screens.
- Ensured form labels adjust their positioning for smaller screens.

These changes mirror the responsive patterns used in the edit-profile component.