### PR TITLE
feat: Add pagination to TailType, TailStatus, and TailLevel controllers

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/AlertController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/AlertController.java
@@ -22,6 +22,9 @@ import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATIO
 @RequestMapping(path = {"/ninetails/alert"}, produces = APPLICATION_JSON)
 public class AlertController {
 
+    private static final int TITLE_MAX_LENGTH = 255;
+    private static final int DESCRIPTION_MAX_LENGTH = 255;
+
     private final AlertService alertService;
     private final N1neTokenService n1neTokenService;
 
@@ -38,9 +41,8 @@ public class AlertController {
         log.info("RECEIVED KUDA REQUEST");
 
         // substring title and description to meet db requirements
-        // todo look into possibly increasing the title and description length
-        if (request.getTitle().length() >= 252) request.setTitle(request.getTitle().substring(0, 252) + "...");
-        if (request.getDescription().length() >= 252) request.setDescription(request.getDescription().substring(0, 252) + "...");
+        request.setTitle(truncate(request.getTitle(), TITLE_MAX_LENGTH));
+        request.setDescription(truncate(request.getDescription(), DESCRIPTION_MAX_LENGTH));
 
         boolean tokenValid = this.n1neTokenService.validateToken(n1neToken);
         if (tokenValid) {
@@ -53,5 +55,12 @@ public class AlertController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         return ResponseEntity.noContent().build();
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null || value.isBlank() || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength - 3) + "...";
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
@@ -3,6 +3,7 @@ package com.n1netails.n1netails.api.controller;
 import com.n1netails.n1netails.api.exception.type.TailLevelNotFoundException;
 import com.n1netails.n1netails.api.model.core.TailLevel;
 import com.n1netails.n1netails.api.model.response.HttpErrorResponse;
+import com.n1netails.n1netails.api.model.request.PageRequest;
 import com.n1netails.n1netails.api.model.response.TailLevelResponse;
 import com.n1netails.n1netails.api.service.TailLevelService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,8 +38,8 @@ public class TailLevelController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailLevelResponse.class))))
     })
     @GetMapping
-    public ResponseEntity<List<TailLevelResponse>> getTailLevels() {
-        return ResponseEntity.ok(tailLevelService.getTailLevels());
+    public ResponseEntity<Page<TailLevelResponse>> getTailLevels(PageRequest request) {
+        return ResponseEntity.ok(tailLevelService.getTailLevels(request));
     }
 
     @Operation(summary = "Get tail level by ID", responses = {

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailLevelController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,7 +39,7 @@ public class TailLevelController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailLevelResponse.class))))
     })
     @GetMapping
-    public ResponseEntity<Page<TailLevelResponse>> getTailLevels(PageRequest request) {
+    public ResponseEntity<Page<TailLevelResponse>> getTailLevels(@ParameterObject PageRequest request) {
         return ResponseEntity.ok(tailLevelService.getTailLevels(request));
     }
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailStatusController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailStatusController.java
@@ -4,6 +4,7 @@ import com.n1netails.n1netails.api.exception.type.TailStatusNotFoundException;
 import com.n1netails.n1netails.api.model.core.TailStatus;
 import com.n1netails.n1netails.api.model.response.HttpErrorResponse;
 import com.n1netails.n1netails.api.model.response.TailLevelResponse;
+import com.n1netails.n1netails.api.model.request.PageRequest;
 import com.n1netails.n1netails.api.model.response.TailStatusResponse;
 import com.n1netails.n1netails.api.service.TailStatusService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,8 +39,8 @@ public class TailStatusController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailStatusResponse.class))))
     })
     @GetMapping
-    public ResponseEntity<List<TailStatusResponse>> getTailStatusList() {
-        return ResponseEntity.ok(tailStatusService.getTailStatusList());
+    public ResponseEntity<Page<TailStatusResponse>> getTailStatusList(PageRequest request) {
+        return ResponseEntity.ok(tailStatusService.getTailStatusList(request));
     }
 
     @Operation(summary = "Get tail status by ID", responses = {

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailStatusController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailStatusController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -39,7 +40,7 @@ public class TailStatusController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailStatusResponse.class))))
     })
     @GetMapping
-    public ResponseEntity<Page<TailStatusResponse>> getTailStatusList(PageRequest request) {
+    public ResponseEntity<Page<TailStatusResponse>> getTailStatusList(@ParameterObject PageRequest request) {
         return ResponseEntity.ok(tailStatusService.getTailStatusList(request));
     }
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailTypeController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailTypeController.java
@@ -3,6 +3,7 @@ package com.n1netails.n1netails.api.controller;
 import com.n1netails.n1netails.api.exception.type.TailTypeNotFoundException;
 import com.n1netails.n1netails.api.model.core.TailType;
 import com.n1netails.n1netails.api.model.response.HttpErrorResponse;
+import com.n1netails.n1netails.api.model.request.PageRequest;
 import com.n1netails.n1netails.api.model.response.TailTypeResponse;
 import com.n1netails.n1netails.api.service.TailTypeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,8 +38,8 @@ public class TailTypeController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailTypeResponse.class))))
     })
     @GetMapping
-    public ResponseEntity<List<TailTypeResponse>> getTailTypes() {
-        return ResponseEntity.ok(tailTypeService.getTailTypes());
+    public ResponseEntity<Page<TailTypeResponse>> getTailTypes(PageRequest request) {
+        return ResponseEntity.ok(tailTypeService.getTailTypes(request));
     }
 
     @Operation(summary = "Get tail type by ID", responses = {

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailTypeController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailTypeController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,7 +39,7 @@ public class TailTypeController {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = TailTypeResponse.class))))
     })
     @GetMapping
-    public ResponseEntity<Page<TailTypeResponse>> getTailTypes(PageRequest request) {
+    public ResponseEntity<Page<TailTypeResponse>> getTailTypes(@ParameterObject PageRequest request) {
         return ResponseEntity.ok(tailTypeService.getTailTypes(request));
     }
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/PageRequest.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/request/PageRequest.java
@@ -1,0 +1,15 @@
+package com.n1netails.n1netails.api.model.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@Setter
+public class PageRequest {
+    private int pageNumber = 0;
+    private int pageSize = 10;
+    private Sort.Direction sortDirection = Sort.Direction.ASC;
+    private String sortBy = "id";
+    private String searchTerm;
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailLevelRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailLevelRepository.java
@@ -1,13 +1,18 @@
 package com.n1netails.n1netails.api.repository;
 
 import com.n1netails.n1netails.api.model.entity.TailLevelEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface TailLevelRepository extends JpaRepository<TailLevelEntity, Long> {
+public interface TailLevelRepository extends PagingAndSortingRepository<TailLevelEntity, Long>, JpaRepository<TailLevelEntity, Long> {
 
     Optional<TailLevelEntity> findTailLevelByName(String name);
+
+    Page<TailLevelEntity> findByNameContainingIgnoreCase(String searchTerm, Pageable pageable);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailStatusRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailStatusRepository.java
@@ -1,13 +1,18 @@
 package com.n1netails.n1netails.api.repository;
 
 import com.n1netails.n1netails.api.model.entity.TailStatusEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface TailStatusRepository extends JpaRepository<TailStatusEntity, Long> {
+public interface TailStatusRepository extends PagingAndSortingRepository<TailStatusEntity, Long>, JpaRepository<TailStatusEntity, Long> {
 
     Optional<TailStatusEntity> findTailStatusByName(String name);
+
+    Page<TailStatusEntity> findByNameContainingIgnoreCase(String searchTerm, Pageable pageable);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailTypeRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailTypeRepository.java
@@ -1,13 +1,18 @@
 package com.n1netails.n1netails.api.repository;
 
 import com.n1netails.n1netails.api.model.entity.TailTypeEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface TailTypeRepository extends JpaRepository<TailTypeEntity, Long> {
+public interface TailTypeRepository extends PagingAndSortingRepository<TailTypeEntity, Long>, JpaRepository<TailTypeEntity, Long> {
 
     Optional<TailTypeEntity> findTailTypeByName(String name);
+
+    Page<TailTypeEntity> findByNameContainingIgnoreCase(String searchTerm, Pageable pageable);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailLevelService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailLevelService.java
@@ -2,13 +2,15 @@ package com.n1netails.n1netails.api.service;
 
 import com.n1netails.n1netails.api.exception.type.TailLevelNotFoundException;
 import com.n1netails.n1netails.api.model.core.TailLevel;
+import com.n1netails.n1netails.api.model.request.PageRequest;
 import com.n1netails.n1netails.api.model.response.TailLevelResponse;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface TailLevelService {
 
-    List<TailLevelResponse> getTailLevels();
+    Page<TailLevelResponse> getTailLevels(PageRequest request);
     TailLevelResponse getTailLevelById(Long id);
     TailLevelResponse createTailLevel(TailLevel request);
     TailLevelResponse updateTailLevel(Long id, TailLevel request);

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailStatusService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailStatusService.java
@@ -2,13 +2,15 @@ package com.n1netails.n1netails.api.service;
 
 import com.n1netails.n1netails.api.exception.type.TailStatusNotFoundException;
 import com.n1netails.n1netails.api.model.core.TailStatus;
+import com.n1netails.n1netails.api.model.request.PageRequest;
 import com.n1netails.n1netails.api.model.response.TailStatusResponse;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface TailStatusService {
 
-    List<TailStatusResponse> getTailStatusList();
+    Page<TailStatusResponse> getTailStatusList(PageRequest request);
     TailStatusResponse getTailStatusById(Long id);
     TailStatusResponse createTailStatus(TailStatus request);
     TailStatusResponse updateTailStatus(Long id, TailStatus request);

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailTypeService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailTypeService.java
@@ -2,13 +2,15 @@ package com.n1netails.n1netails.api.service;
 
 import com.n1netails.n1netails.api.exception.type.TailTypeNotFoundException;
 import com.n1netails.n1netails.api.model.core.TailType;
+import com.n1netails.n1netails.api.model.request.PageRequest;
 import com.n1netails.n1netails.api.model.response.TailTypeResponse;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface TailTypeService {
 
-    List<TailTypeResponse> getTailTypes();
+    Page<TailTypeResponse> getTailTypes(PageRequest request);
     TailTypeResponse getTailTypeById(Long id);
     TailTypeResponse createTailType(TailType request);
     TailTypeResponse updateTailType(Long id, TailType request);

--- a/n1netails-ui/src/main/typescript/src/app/model/interface/page.interface.ts
+++ b/n1netails-ui/src/main/typescript/src/app/model/interface/page.interface.ts
@@ -1,0 +1,15 @@
+export interface PageRequest {
+    pageNumber: number;
+    pageSize: number;
+    sortDirection: string;
+    sortBy: string;
+    searchTerm?: string;
+}
+
+export interface PageResponse<T> {
+    content: T[];
+    totalPages: number;
+    totalElements: number;
+    size: number;
+    number: number; // current page number
+}

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
@@ -159,6 +159,10 @@
               <div class="alert-management">
                 <div class="alert-list">
                   <h4>Tail Levels</h4>
+                  <div class="alert-add-form">
+                    <input nz-input [(ngModel)]="searchTailLevel" (ngModelChange)="searchLevels()" name="searchTailLevel" placeholder="Search level" class="alert-input"/>
+                    <button nz-button nzType="default" (click)="searchLevels()" class="alert-add-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
+                  </div>
                   <ul>
                     <li *ngFor="let level of tailLevels">
                       {{ level.name }}
@@ -172,6 +176,10 @@
                 </div>
                 <div class="alert-list">
                   <h4>Tail Statuses</h4>
+                  <div class="alert-add-form">
+                    <input nz-input [(ngModel)]="searchTailStatus" (ngModelChange)="searchStatuses()" name="searchTailStatus" placeholder="Search status" class="alert-input"/>
+                    <button nz-button nzType="default" (click)="searchStatuses()" class="alert-add-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
+                  </div>
                   <ul>
                     <li *ngFor="let status of tailStatuses">
                       {{ status.name }}
@@ -185,6 +193,10 @@
                 </div>
                 <div class="alert-list">
                   <h4>Tail Types</h4>
+                  <div class="alert-add-form">
+                    <input nz-input [(ngModel)]="searchTailType" (ngModelChange)="searchType()" name="searchTailType" placeholder="Search type" class="alert-input"/>
+                    <button nz-button nzType="default" (click)="searchType()" class="alert-add-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
+                  </div>
                   <ul>
                     <li *ngFor="let type of tailTypes">
                       {{ type.name }}

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.html
@@ -159,9 +159,9 @@
               <div class="alert-management">
                 <div class="alert-list">
                   <h4>Tail Levels</h4>
-                  <div class="alert-add-form">
+                  <div class="alert-form">
                     <input nz-input [(ngModel)]="searchTailLevel" (ngModelChange)="searchLevels()" name="searchTailLevel" placeholder="Search level" class="alert-input"/>
-                    <button nz-button nzType="default" (click)="searchLevels()" class="alert-add-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
+                    <button nz-button nzType="default" (click)="searchLevels()" class="alert-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
                   </div>
                   <ul>
                     <li *ngFor="let level of tailLevels">
@@ -169,16 +169,16 @@
                       <button *ngIf="level.deletable" nz-button nzType="link" nzDanger (click)="removeAlertLevel(level.name)">Remove</button>
                     </li>
                   </ul>
-                  <div class="alert-add-form">
+                  <div class="alert-form">
                     <input nz-input [(ngModel)]="newTailLevel" name="newTailLevel" placeholder="Add new level" class="alert-input"/>
-                    <button nz-button nzType="default" (click)="addAlertLevel()" class="alert-add-btn">+</button>
+                    <button nz-button nzType="default" (click)="addAlertLevel()" class="alert-btn">+</button>
                   </div>
                 </div>
                 <div class="alert-list">
                   <h4>Tail Statuses</h4>
-                  <div class="alert-add-form">
+                  <div class="alert-form">
                     <input nz-input [(ngModel)]="searchTailStatus" (ngModelChange)="searchStatuses()" name="searchTailStatus" placeholder="Search status" class="alert-input"/>
-                    <button nz-button nzType="default" (click)="searchStatuses()" class="alert-add-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
+                    <button nz-button nzType="default" (click)="searchStatuses()" class="alert-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
                   </div>
                   <ul>
                     <li *ngFor="let status of tailStatuses">
@@ -186,16 +186,16 @@
                       <button *ngIf="status.deletable" nz-button nzType="link" nzDanger (click)="removeAlertStatus(status.name)">Remove</button>
                     </li>
                   </ul>
-                  <div class="alert-add-form">
+                  <div class="alert-form">
                     <input nz-input [(ngModel)]="newTailStatus" name="newTailStatus" placeholder="Add new status" class="alert-input"/>
-                    <button nz-button nzType="default" (click)="addAlertStatus()" class="alert-add-btn">+</button>
+                    <button nz-button nzType="default" (click)="addAlertStatus()" class="alert-btn">+</button>
                   </div>
                 </div>
                 <div class="alert-list">
                   <h4>Tail Types</h4>
-                  <div class="alert-add-form">
+                  <div class="alert-form">
                     <input nz-input [(ngModel)]="searchTailType" (ngModelChange)="searchType()" name="searchTailType" placeholder="Search type" class="alert-input"/>
-                    <button nz-button nzType="default" (click)="searchType()" class="alert-add-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
+                    <button nz-button nzType="default" (click)="searchType()" class="alert-btn"><nz-icon nzType="search" nzTheme="outline" /></button>
                   </div>
                   <ul>
                     <li *ngFor="let type of tailTypes">
@@ -203,9 +203,9 @@
                       <button *ngIf="type.deletable" nz-button nzType="link" nzDanger (click)="removeAlertType(type.name)">Remove</button>
                     </li>
                   </ul>
-                  <div class="alert-add-form">
+                  <div class="alert-form">
                     <input nz-input [(ngModel)]="newTailType" name="newTailType" placeholder="Add new type" class="alert-input"/>
-                    <button nz-button nzType="default" (click)="addAlertType()" class="alert-add-btn">+</button>
+                    <button nz-button nzType="default" (click)="addAlertType()" class="alert-btn">+</button>
                   </div>
                 </div>
               </div>

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.less
@@ -85,7 +85,7 @@ button[nz-button] {
       }
     }
 
-    .alert-add-form {
+    .alert-form {
       display: flex;
       gap: 8px; // Space between input and button
 
@@ -93,14 +93,14 @@ button[nz-button] {
         flex-grow: 1; // Input takes available space
       }
 
-      .alert-add-btn { // Class added in HTML
+      .alert-btn { // Class added in HTML
         padding-left: 13px;
         padding-right: 13px;
       }
 
       @media (max-width: @screen-xs-max) { // Very small screens
         flex-direction: column; // Stack input and button
-        .alert-input, .alert-add-btn {
+        .alert-input, .alert-btn {
           width: 100%; // Both take full width when stacked
         }
       }

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -90,9 +90,7 @@ export class SettingsComponent implements OnInit {
       sortBy: "id"
     };
     this.tailLevelService.getTailLevels(pageRequest).subscribe((response: PageResponse<TailLevelResponse>) => {
-      console.log('tail levels', response);
       this.tailLevels = response.content;
-      console.log('LEVELS', this.tailLevels);
     });
   }
 
@@ -116,7 +114,6 @@ export class SettingsComponent implements OnInit {
       sortBy: "id"
     };
     this.tailTypeService.getTailTypes(pageRequest).subscribe((response: PageResponse<TailTypeResponse>) => {
-      console.log('tail type list', response);
       this.tailTypes = response.content;
       this.updateAlertTypeOptions();
     });
@@ -352,9 +349,7 @@ export class SettingsComponent implements OnInit {
       searchTerm: this.searchTailLevel
     };
     this.tailLevelService.getTailLevels(pageRequest).subscribe((response: PageResponse<TailLevelResponse>) => {
-      console.log('tail levels', response);
       this.tailLevels = response.content;
-      console.log('LEVELS', this.tailLevels);
     });
   }
 
@@ -380,7 +375,6 @@ export class SettingsComponent implements OnInit {
       searchTerm: this.searchTailType
     };
     this.tailTypeService.getTailTypes(pageRequest).subscribe((response: PageResponse<TailTypeResponse>) => {
-      console.log('tail type list', response);
       this.tailTypes = response.content;
     });
   }

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -19,6 +19,7 @@ import { Organization } from '../../model/organization';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 import { PageRequest, PageResponse } from '../../model/interface/page.interface';
 import { NzIconModule } from 'ng-zorro-antd/icon';
+import { PageUtilService } from '../../shared/page-util.service';
 
 @Component({
   selector: 'app-settings',
@@ -69,6 +70,7 @@ export class SettingsComponent implements OnInit {
     private tailStatusService: TailStatusService,
     private tailTypeService: TailTypeService,
     private n1neTokenService: N1neTokenService,
+    private pageUtilService: PageUtilService
   ) {
     this.updateAlertTypeOptions();
     this.user = this.authenticationService.getUserFromLocalCache();
@@ -83,36 +85,21 @@ export class SettingsComponent implements OnInit {
   }
 
   private listTailLevels() {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id"
-    };
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequest();
     this.tailLevelService.getTailLevels(pageRequest).subscribe((response: PageResponse<TailLevelResponse>) => {
       this.tailLevels = response.content;
     });
   }
 
     private listTailStatus() {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id"
-    };
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequest();
     this.tailStatusService.getTailStatusList(pageRequest).subscribe((response: PageResponse<TailStatusResponse>) => {
       this.tailStatuses = response.content;
     });
   }
 
   private listTailTypes() {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id"
-    };
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequest();
     this.tailTypeService.getTailTypes(pageRequest).subscribe((response: PageResponse<TailTypeResponse>) => {
       this.tailTypes = response.content;
       this.updateAlertTypeOptions();
@@ -341,39 +328,21 @@ export class SettingsComponent implements OnInit {
   }
 
   searchLevels() {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id",
-      searchTerm: this.searchTailLevel
-    };
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequestWithSearch(this.searchTailLevel);
     this.tailLevelService.getTailLevels(pageRequest).subscribe((response: PageResponse<TailLevelResponse>) => {
       this.tailLevels = response.content;
     });
   }
 
   searchStatuses() {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id",
-      searchTerm: this.searchTailStatus
-    };
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequestWithSearch(this.searchTailStatus);
     this.tailStatusService.getTailStatusList(pageRequest).subscribe((response: PageResponse<TailStatusResponse>) => {
       this.tailStatuses = response.content;
     });
   }
 
   searchType() {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id",
-      searchTerm: this.searchTailType
-    };
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequestWithSearch(this.searchTailType);
     this.tailTypeService.getTailTypes(pageRequest).subscribe((response: PageResponse<TailTypeResponse>) => {
       this.tailTypes = response.content;
     });

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -18,6 +18,7 @@ import { NzDividerModule } from 'ng-zorro-antd/divider';
 import { Organization } from '../../model/organization';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 import { PageRequest, PageResponse } from '../../model/interface/page.interface';
+import { NzIconModule } from 'ng-zorro-antd/icon';
 
 @Component({
   selector: 'app-settings',
@@ -33,6 +34,7 @@ import { PageRequest, PageResponse } from '../../model/interface/page.interface'
     CommonModule,
     NzDividerModule,
     NzSelectModule,
+    NzIconModule
   ],
   templateUrl: './settings.component.html',
   styleUrl: './settings.component.less'
@@ -56,6 +58,10 @@ export class SettingsComponent implements OnInit {
   newTailLevel: string = '';
   newTailStatus: string = '';
   newTailType: string = '';
+
+  searchTailLevel: string = '';
+  searchTailStatus: string = '';
+  searchTailType: string = '';
 
   constructor(
     private authenticationService: AuthenticationService,
@@ -335,5 +341,47 @@ export class SettingsComponent implements OnInit {
     // - Modify /n1netails-liquibase and /n1netails-api services in the root directory to include and save the user's preferred tail types.
     // - If tail types do not exist in the tail types list, they should be removed from the user's preferred tail types as well.
     //   This does not need to be corrected until the user checks to confirm and view their preferred tail type list.
+  }
+
+  searchLevels() {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id",
+      searchTerm: this.searchTailLevel
+    };
+    this.tailLevelService.getTailLevels(pageRequest).subscribe((response: PageResponse<TailLevelResponse>) => {
+      console.log('tail levels', response);
+      this.tailLevels = response.content;
+      console.log('LEVELS', this.tailLevels);
+    });
+  }
+
+  searchStatuses() {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id",
+      searchTerm: this.searchTailStatus
+    };
+    this.tailStatusService.getTailStatusList(pageRequest).subscribe((response: PageResponse<TailStatusResponse>) => {
+      this.tailStatuses = response.content;
+    });
+  }
+
+  searchType() {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id",
+      searchTerm: this.searchTailType
+    };
+    this.tailTypeService.getTailTypes(pageRequest).subscribe((response: PageResponse<TailTypeResponse>) => {
+      console.log('tail type list', response);
+      this.tailTypes = response.content;
+    });
   }
 }

--- a/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/settings/settings.component.ts
@@ -17,6 +17,7 @@ import { N1neTokenService, N1neTokenResponse, CreateTokenRequest } from '../../s
 import { NzDividerModule } from 'ng-zorro-antd/divider';
 import { Organization } from '../../model/organization';
 import { NzSelectModule } from 'ng-zorro-antd/select';
+import { PageRequest, PageResponse } from '../../model/interface/page.interface';
 
 @Component({
   selector: 'app-settings',
@@ -70,15 +71,48 @@ export class SettingsComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadTokens(); // Load tokens on init
-    this.tailLevelService.getTailLevels().subscribe((response: TailLevelResponse[]) => {
-      this.tailLevels = response;
+    this.listTailLevels();
+    this.listTailStatus();
+    this.listTailTypes();
+  }
+
+  private listTailLevels() {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id"
+    };
+    this.tailLevelService.getTailLevels(pageRequest).subscribe((response: PageResponse<TailLevelResponse>) => {
+      console.log('tail levels', response);
+      this.tailLevels = response.content;
+      console.log('LEVELS', this.tailLevels);
     });
-    this.tailStatusService.getTailStatusList().subscribe((response: TailStatusResponse[]) => {
-      this.tailStatuses = response;
+  }
+
+    private listTailStatus() {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id"
+    };
+    this.tailStatusService.getTailStatusList(pageRequest).subscribe((response: PageResponse<TailStatusResponse>) => {
+      this.tailStatuses = response.content;
     });
-    this.tailTypeService.getTailTypes().subscribe((response: TailTypeResponse[]) => {
-      this.tailTypes = response;
-      this.updateAlertTypeOptions(); // Call after loading tail types
+  }
+
+  private listTailTypes() {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id"
+    };
+    this.tailTypeService.getTailTypes(pageRequest).subscribe((response: PageResponse<TailTypeResponse>) => {
+      console.log('tail type list', response);
+      this.tailTypes = response.content;
+      this.updateAlertTypeOptions();
     });
   }
 
@@ -277,16 +311,17 @@ export class SettingsComponent implements OnInit {
   preferredAlertTypes: string[] = [];
 
   updateAlertTypeOptions() {
-    this.tailTypeService.getTailTypes().subscribe((response: TailTypeResponse[]) => {
-      this.alertTypeOptions = response.map(type => ({
-        label: type.name,
-        value: type.name,
-        // `checked` property can be managed based on `preferredAlertTypes`
-        // For now, we just populate the options.
-        // checked: this.preferredAlertTypes.includes(type.name)
-      }));
-      console.log('Updated alertTypeOptions:', this.alertTypeOptions);
-    });
+    // TODO CONSIDER REMOVING THIS
+    // this.tailTypeService.getTailTypes().subscribe((response: TailTypeResponse[]) => {
+    //   this.alertTypeOptions = response.map(type => ({
+    //     label: type.name,
+    //     value: type.name,
+    //     // `checked` property can be managed based on `preferredAlertTypes`
+    //     // For now, we just populate the options.
+    //     // checked: this.preferredAlertTypes.includes(type.name)
+    //   }));
+    //   console.log('Updated alertTypeOptions:', this.alertTypeOptions);
+    // });
   }
 
   onSavePreferredTypes() {

--- a/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.ts
@@ -117,7 +117,6 @@ export class TailComponent implements OnInit {
     this.isLoading = true;
     this.tailService.getTailById(id).subscribe({
       next: (data) => {
-        console.log('TAIL DATA', data);
         this.tail = data;
         if (this.tail && this.tail.metadata) {
           this.metadataKeys = Object.keys(this.tail.metadata);
@@ -138,7 +137,6 @@ export class TailComponent implements OnInit {
     if (id !== undefined) {
       this.noteService.getN1Note(id).subscribe({
         next: (data) => {
-          console.log('N1 Note: ', data);
           this.n1Note = data;
         }
       });

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.html
@@ -28,6 +28,8 @@
                   (ngModelChange)="onFilterChange()"
                   nzAllowClear
                   nzPlaceHolder="Status"
+                  nzShowSearch
+                  (nzOnSearch)="onStatusSearch($event)"
                   style="width: 140px; margin-right: 12px;"
                 >
                   <nz-option nzValue="" nzLabel="All"></nz-option>
@@ -42,6 +44,8 @@
                   (ngModelChange)="onFilterChange()"
                   nzAllowClear
                   nzPlaceHolder="Type"
+                  nzShowSearch
+                  (nzOnSearch)="onTypeSearch($event)"
                   style="width: 160px; margin-right: 12px;"
                 >
                   <nz-option nzValue="" nzLabel="All"></nz-option>
@@ -56,6 +60,8 @@
                   (ngModelChange)="onFilterChange()"
                   nzAllowClear
                   nzPlaceHolder="Level"
+                  nzShowSearch
+                  (nzOnSearch)="onLevelSearch($event)"
                   style="width: 120px;"
                 >
                   <nz-option nzValue="" nzLabel="All"></nz-option>

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
@@ -149,7 +149,6 @@ export class TailsComponent implements OnInit {
   }
 
   onStatusSearch(term: string): void {
-    console.log('on status search');
     const pageRequest: PageRequest = {
       pageNumber: 0,
       pageSize: 50,
@@ -165,7 +164,6 @@ export class TailsComponent implements OnInit {
   } 
 
   onTypeSearch(term: string): void {
-    console.log('on type search');
     const pageRequest: PageRequest = {
       pageNumber: 0,
       pageSize: 50,
@@ -181,7 +179,6 @@ export class TailsComponent implements OnInit {
   } 
 
     onLevelSearch(term: string): void {
-    console.log('on level search');
     const pageRequest: PageRequest = {
       pageNumber: 0,
       pageSize: 50,

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
@@ -127,17 +127,20 @@ export class TailsComponent implements OnInit {
   }
 
   loadTailInfoData(): void {
-    this.tailLevelService.getTailLevels().subscribe(result => {
-      result.forEach(level => this.tailLevels.push(level.name));
-    });
+    // TODO FIX FOR PAGINATION
+    // this.tailLevelService.getTailLevels().subscribe(result => {
+    //   result.forEach(level => this.tailLevels.push(level.name));
+    // });
 
-    this.tailStatusService.getTailStatusList().subscribe(result => {
-      result.forEach(status => this.tailStatusList.push(status.name));
-    });
+    // TODO FIX FOR PAGINATION
+    // this.tailStatusService.getTailStatusList().subscribe(result => {
+    //   result.forEach(status => this.tailStatusList.push(status.name));
+    // });
 
-    this.tailTypeService.getTailTypes().subscribe(result => {
-      result.forEach(type => this.tailTypes.push(type.name));
-    });
+    // TODO FIX FOR PAGINATION
+    // this.tailTypeService.getTailTypes().subscribe(result => {
+    //   result.forEach(type => this.tailTypes.push(type.name));
+    // });
   }
 
   onSearchTermChange(): void {

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
@@ -148,6 +148,54 @@ export class TailsComponent implements OnInit {
     });
   }
 
+  onStatusSearch(term: string): void {
+    console.log('on status search');
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id",
+      searchTerm: term
+    };
+
+    this.tailStatusService.getTailStatusList(pageRequest).subscribe(result => {
+      this.tailStatusList = [];
+      result.content.forEach(status => this.tailStatusList.push(status.name));
+    });
+  } 
+
+  onTypeSearch(term: string): void {
+    console.log('on type search');
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id",
+      searchTerm: term
+    };
+
+    this.tailTypeService.getTailTypes(pageRequest).subscribe(result => {
+      this.tailTypes = [];
+      result.content.forEach(type => this.tailTypes.push(type.name));
+    });
+  } 
+
+    onLevelSearch(term: string): void {
+    console.log('on level search');
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id",
+      searchTerm: term
+    };
+
+    this.tailLevelService.getTailLevels(pageRequest).subscribe(result => {
+      this.tailLevels = [];
+      result.content.forEach(level => this.tailLevels.push(level.name));
+    });
+  } 
+
   onSearchTermChange(): void {
     this.currentPage = 0; // Reset to first page on new search
     this.loadTails();

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
@@ -24,6 +24,7 @@ import { AuthenticationService } from '../../service/authentication.service';
 import { TailService } from '../../service/tail.service';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { ResolveTailRequest, TailSummary } from '../../model/tail.model';
+import { PageRequest } from '../../model/interface/page.interface';
 
 @Component({
   selector: 'app-tails',
@@ -127,20 +128,24 @@ export class TailsComponent implements OnInit {
   }
 
   loadTailInfoData(): void {
-    // TODO FIX FOR PAGINATION
-    // this.tailLevelService.getTailLevels().subscribe(result => {
-    //   result.forEach(level => this.tailLevels.push(level.name));
-    // });
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id"
+    };
 
-    // TODO FIX FOR PAGINATION
-    // this.tailStatusService.getTailStatusList().subscribe(result => {
-    //   result.forEach(status => this.tailStatusList.push(status.name));
-    // });
+    this.tailLevelService.getTailLevels(pageRequest).subscribe(result => {
+      result.content.forEach(level => this.tailLevels.push(level.name));
+    });
 
-    // TODO FIX FOR PAGINATION
-    // this.tailTypeService.getTailTypes().subscribe(result => {
-    //   result.forEach(type => this.tailTypes.push(type.name));
-    // });
+    this.tailStatusService.getTailStatusList(pageRequest).subscribe(result => {
+      result.content.forEach(status => this.tailStatusList.push(status.name));
+    });
+
+    this.tailTypeService.getTailTypes(pageRequest).subscribe(result => {
+      result.content.forEach(type => this.tailTypes.push(type.name));
+    });
   }
 
   onSearchTermChange(): void {

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
@@ -25,6 +25,7 @@ import { TailService } from '../../service/tail.service';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { ResolveTailRequest, TailSummary } from '../../model/tail.model';
 import { PageRequest } from '../../model/interface/page.interface';
+import { PageUtilService } from '../../shared/page-util.service';
 
 @Component({
   selector: 'app-tails',
@@ -81,7 +82,8 @@ export class TailsComponent implements OnInit {
     private tailService: TailService,
     private authenticationService: AuthenticationService,
     private messageService: NzMessageService,
-    private router: Router
+    private router: Router,
+    private pageUtilService: PageUtilService
   ) {
     this.currentUser = this.authenticationService.getUserFromLocalCache();
   }
@@ -128,12 +130,7 @@ export class TailsComponent implements OnInit {
   }
 
   loadTailInfoData(): void {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id"
-    };
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequest();
 
     this.tailLevelService.getTailLevels(pageRequest).subscribe(result => {
       result.content.forEach(level => this.tailLevels.push(level.name));
@@ -149,14 +146,7 @@ export class TailsComponent implements OnInit {
   }
 
   onStatusSearch(term: string): void {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id",
-      searchTerm: term
-    };
-
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequestWithSearch(term);
     this.tailStatusService.getTailStatusList(pageRequest).subscribe(result => {
       this.tailStatusList = [];
       result.content.forEach(status => this.tailStatusList.push(status.name));
@@ -164,29 +154,15 @@ export class TailsComponent implements OnInit {
   } 
 
   onTypeSearch(term: string): void {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id",
-      searchTerm: term
-    };
-
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequestWithSearch(term);
     this.tailTypeService.getTailTypes(pageRequest).subscribe(result => {
       this.tailTypes = [];
       result.content.forEach(type => this.tailTypes.push(type.name));
     });
   } 
 
-    onLevelSearch(term: string): void {
-    const pageRequest: PageRequest = {
-      pageNumber: 0,
-      pageSize: 50,
-      sortDirection: "ASC",
-      sortBy: "id",
-      searchTerm: term
-    };
-
+  onLevelSearch(term: string): void {
+    const pageRequest: PageRequest = this.pageUtilService.setDefaultPageRequestWithSearch(term);
     this.tailLevelService.getTailLevels(pageRequest).subscribe(result => {
       this.tailLevels = [];
       result.content.forEach(level => this.tailLevels.push(level.name));

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-level.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-level.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UiConfigService } from '../shared/ui-config.service';
+import { PageResponse, PageRequest } from '../model/interface/page.interface';
 
 export interface TailLevel {
   name: string;
@@ -34,9 +35,20 @@ export class TailLevelService {
     return this.http.post<TailLevelResponse>(this.host, request);
   }
 
-  getTailLevels(): Observable<TailLevelResponse[]> {
+  getTailLevels(pageRequest: PageRequest): Observable<PageResponse<TailLevelResponse>> {
+
+    let params = new HttpParams()
+      .set('pageNumber', pageRequest.pageNumber)
+      .set('pageSize', pageRequest.pageSize)
+      .set('sortDirection', pageRequest.sortDirection)
+      .set('sortBy', pageRequest.sortBy);
+
+    if (pageRequest.searchTerm) {
+      params = params.set('searchTerm', pageRequest.searchTerm);
+    }
+
     this.host = this.uiConfigService.getApiUrl() + this.apiUrl;
-    return this.http.get<TailLevelResponse[]>(this.host);
+    return this.http.get<PageResponse<TailLevelResponse>>(this.host, { params });
   }
 
   getTailLevelById(id: number): Observable<TailLevelResponse> {

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-level.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-level.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UiConfigService } from '../shared/ui-config.service';
 import { PageResponse, PageRequest } from '../model/interface/page.interface';
+import { PageUtilService } from '../shared/page-util.service';
 
 export interface TailLevel {
   name: string;
@@ -27,7 +28,8 @@ export class TailLevelService {
 
   constructor(
     private http: HttpClient, 
-    private uiConfigService: UiConfigService
+    private uiConfigService: UiConfigService,
+    private pageUtilService: PageUtilService
   ) {}
 
   createTailLevel(request: TailLevel): Observable<TailLevelResponse> {
@@ -36,17 +38,7 @@ export class TailLevelService {
   }
 
   getTailLevels(pageRequest: PageRequest): Observable<PageResponse<TailLevelResponse>> {
-
-    let params = new HttpParams()
-      .set('pageNumber', pageRequest.pageNumber)
-      .set('pageSize', pageRequest.pageSize)
-      .set('sortDirection', pageRequest.sortDirection)
-      .set('sortBy', pageRequest.sortBy);
-
-    if (pageRequest.searchTerm) {
-      params = params.set('searchTerm', pageRequest.searchTerm);
-    }
-
+    let params = this.pageUtilService.getPageRequestParams(pageRequest);
     this.host = this.uiConfigService.getApiUrl() + this.apiUrl;
     return this.http.get<PageResponse<TailLevelResponse>>(this.host, { params });
   }

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-status.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-status.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UiConfigService } from '../shared/ui-config.service';
+import { PageRequest, PageResponse } from '../model/interface/page.interface';
 
 export interface TailStatus {
   name: string;
@@ -32,9 +33,20 @@ export class TailStatusService {
     return this.http.post<TailStatusResponse>(this.host, request);
   }
 
-  getTailStatusList(): Observable<TailStatusResponse[]> {
+  getTailStatusList(pageRequest: PageRequest): Observable<PageResponse<TailStatusResponse>> {
+
+    let params = new HttpParams()
+      .set('pageNumber', pageRequest.pageNumber)
+      .set('pageSize', pageRequest.pageSize)
+      .set('sortDirection', pageRequest.sortDirection)
+      .set('sortBy', pageRequest.sortBy);
+
+    if (pageRequest.searchTerm) {
+      params = params.set('searchTerm', pageRequest.searchTerm);
+    }
+
     this.host = this.uiConfigService.getApiUrl() + this.apiUrl;
-    return this.http.get<TailStatusResponse[]>(this.host);
+    return this.http.get<PageResponse<TailStatusResponse>>(this.host, { params });
   }
 
   getTailStatusById(id: number): Observable<TailStatusResponse> {

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-status.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-status.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UiConfigService } from '../shared/ui-config.service';
 import { PageRequest, PageResponse } from '../model/interface/page.interface';
+import { PageUtilService } from '../shared/page-util.service';
 
 export interface TailStatus {
   name: string;
@@ -25,7 +26,8 @@ export class TailStatusService {
 
   constructor(
     private http: HttpClient,
-    private uiConfigService: UiConfigService
+    private uiConfigService: UiConfigService,
+    private pageUtilService: PageUtilService
   ) {}
 
   createTailStatus(request: TailStatus): Observable<TailStatusResponse> {
@@ -34,17 +36,7 @@ export class TailStatusService {
   }
 
   getTailStatusList(pageRequest: PageRequest): Observable<PageResponse<TailStatusResponse>> {
-
-    let params = new HttpParams()
-      .set('pageNumber', pageRequest.pageNumber)
-      .set('pageSize', pageRequest.pageSize)
-      .set('sortDirection', pageRequest.sortDirection)
-      .set('sortBy', pageRequest.sortBy);
-
-    if (pageRequest.searchTerm) {
-      params = params.set('searchTerm', pageRequest.searchTerm);
-    }
-
+    let params = this.pageUtilService.getPageRequestParams(pageRequest);
     this.host = this.uiConfigService.getApiUrl() + this.apiUrl;
     return this.http.get<PageResponse<TailStatusResponse>>(this.host, { params });
   }

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-type.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-type.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UiConfigService } from '../shared/ui-config.service';
+import { PageRequest, PageResponse } from '../model/interface/page.interface';
 
 export interface TailType {
   name: string;
@@ -34,9 +35,20 @@ export class TailTypeService {
     return this.http.post<TailTypeResponse>(this.host, request);
   }
 
-  getTailTypes(): Observable<TailTypeResponse[]> {
+  getTailTypes(pageRequest: PageRequest): Observable<PageResponse<TailTypeResponse>> {
+
+    let params = new HttpParams()
+      .set('pageNumber', pageRequest.pageNumber)
+      .set('pageSize', pageRequest.pageSize)
+      .set('sortDirection', pageRequest.sortDirection)
+      .set('sortBy', pageRequest.sortBy);
+
+    if (pageRequest.searchTerm) {
+      params = params.set('searchTerm', pageRequest.searchTerm);
+    }
+
     this.host = this.uiConfigService.getApiUrl() + this.apiUrl;
-    return this.http.get<TailTypeResponse[]>(this.host);
+    return this.http.get<PageResponse<TailTypeResponse>>(this.host, { params });
   }
 
   getTailTypeById(id: number): Observable<TailTypeResponse> {

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-type.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-type.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UiConfigService } from '../shared/ui-config.service';
 import { PageRequest, PageResponse } from '../model/interface/page.interface';
+import { PageUtilService } from '../shared/page-util.service';
 
 export interface TailType {
   name: string;
@@ -27,7 +28,8 @@ export class TailTypeService {
 
   constructor(
     private http: HttpClient,
-    private uiConfigService: UiConfigService
+    private uiConfigService: UiConfigService,
+    private pageUtilService: PageUtilService
   ) {}
 
   createTailType(request: TailType): Observable<TailTypeResponse> {
@@ -36,17 +38,7 @@ export class TailTypeService {
   }
 
   getTailTypes(pageRequest: PageRequest): Observable<PageResponse<TailTypeResponse>> {
-
-    let params = new HttpParams()
-      .set('pageNumber', pageRequest.pageNumber)
-      .set('pageSize', pageRequest.pageSize)
-      .set('sortDirection', pageRequest.sortDirection)
-      .set('sortBy', pageRequest.sortBy);
-
-    if (pageRequest.searchTerm) {
-      params = params.set('searchTerm', pageRequest.searchTerm);
-    }
-
+    let params = this.pageUtilService.getPageRequestParams(pageRequest);
     this.host = this.uiConfigService.getApiUrl() + this.apiUrl;
     return this.http.get<PageResponse<TailTypeResponse>>(this.host, { params });
   }

--- a/n1netails-ui/src/main/typescript/src/app/shared/page-util.service.spec.ts
+++ b/n1netails-ui/src/main/typescript/src/app/shared/page-util.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PageUtilService } from './page-util.service';
+
+describe('PageUtilService', () => {
+  let service: PageUtilService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PageUtilService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/n1netails-ui/src/main/typescript/src/app/shared/page-util.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/shared/page-util.service.ts
@@ -1,0 +1,24 @@
+import { HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { PageRequest } from '../model/interface/page.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PageUtilService {
+
+  constructor() { }
+
+  getPageRequestParams(pageRequest: PageRequest): HttpParams {
+    let params = new HttpParams()
+      .set('pageNumber', pageRequest.pageNumber)
+      .set('pageSize', pageRequest.pageSize)
+      .set('sortDirection', pageRequest.sortDirection)
+      .set('sortBy', pageRequest.sortBy);
+
+    if (pageRequest.searchTerm) {
+      params = params.set('searchTerm', pageRequest.searchTerm);
+    }
+    return params;
+  }
+}

--- a/n1netails-ui/src/main/typescript/src/app/shared/page-util.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/shared/page-util.service.ts
@@ -21,4 +21,25 @@ export class PageUtilService {
     }
     return params;
   }
+
+  setDefaultPageRequest(): PageRequest {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id"
+    };
+    return pageRequest;
+  }
+
+  setDefaultPageRequestWithSearch(term: string): PageRequest {
+    const pageRequest: PageRequest = {
+      pageNumber: 0,
+      pageSize: 50,
+      sortDirection: "ASC",
+      sortBy: "id",
+      searchTerm: term
+    };
+    return pageRequest;
+  }
 }


### PR DESCRIPTION
- Created a PageRequest class to handle pagination and search parameters.
- Updated TailTypeController, TailStatusController, and TailLevelController to accept a PageRequest object and return a Page of responses.
- Updated the corresponding services and repositories to support pagination and searching by name.