### PR TITLE
feat: Add tail bookmarking functionality

### DIFF
--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
@@ -1,11 +1,9 @@
 package com.n1netails.n1netails.api.controller;
 
-import com.n1netails.n1netails.api.exception.type.TailAlreadyBookmarkedException;
-import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
-import com.n1netails.n1netails.api.exception.type.UnauthorizedException;
-import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.exception.type.*;
 import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.entity.TailEntity;
+import com.n1netails.n1netails.api.model.request.TailPageRequest;
 import com.n1netails.n1netails.api.model.response.IsBookmarkedResponse;
 import com.n1netails.n1netails.api.model.response.TailResponse;
 import com.n1netails.n1netails.api.service.AuthorizationService;
@@ -15,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -66,15 +65,16 @@ public class TailBookmarkController {
             @ApiResponse(responseCode = "200", description = "List of bookmarked tails"),
             @ApiResponse(responseCode = "404", description = "User not found")
     })
-    @GetMapping
-    public ResponseEntity<List<TailResponse>> getUserBookmarks(@RequestHeader("Authorization") String authorizationHeader)
-            throws UserNotFoundException, UnauthorizedException {
+    @PostMapping
+    public ResponseEntity<Page<TailResponse>> getUserBookmarks(@RequestBody TailPageRequest request, @RequestHeader("Authorization") String authorizationHeader)
+            throws UserNotFoundException, UnauthorizedException, TailTypeNotFoundException, TailLevelNotFoundException, TailStatusNotFoundException {
         UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
-        List<TailEntity> bookmarks = tailBookmarkService.getUserBookmarks(currentUser.getId());
-        List<TailResponse> response = bookmarks.stream()
-                .map(this::toTailResponse)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(response);
+        Page<TailResponse> bookmarks = tailBookmarkService.getUserBookmarks(request, currentUser);
+        // todo handle page request
+//        List<TailResponse> response = bookmarks.stream()
+//                .map(this::toTailResponse)
+//                .collect(Collectors.toList());
+        return ResponseEntity.ok(bookmarks);
     }
 
     @Operation(summary = "Check if a tail is bookmarked by the current user", responses = {
@@ -92,21 +92,21 @@ public class TailBookmarkController {
         return ResponseEntity.ok(isBookmarkedResponse);
     }
 
-    private TailResponse toTailResponse(TailEntity tailEntity) {
-        return new TailResponse(
-                tailEntity.getId(),
-                tailEntity.getTitle(),
-                tailEntity.getDescription(),
-                tailEntity.getTimestamp(),
-                tailEntity.getResolvedTimestamp(),
-                tailEntity.getAssignedUserId(),
-                null, // assignedUsername is not in TailEntity, so I'll leave it null
-                tailEntity.getDetails(),
-                tailEntity.getLevel() != null ? tailEntity.getLevel().getName() : null,
-                tailEntity.getType() != null ? tailEntity.getType().getName() : null,
-                tailEntity.getStatus() != null ? tailEntity.getStatus().getName() : null,
-                null, // metadata is not in TailEntity
-                tailEntity.getOrganization() != null ? tailEntity.getOrganization().getId() : null
-        );
-    }
+//    private TailResponse toTailResponse(TailEntity tailEntity) {
+//        return new TailResponse(
+//                tailEntity.getId(),
+//                tailEntity.getTitle(),
+//                tailEntity.getDescription(),
+//                tailEntity.getTimestamp(),
+//                tailEntity.getResolvedTimestamp(),
+//                tailEntity.getAssignedUserId(),
+//                null, // assignedUsername is not in TailEntity, so I'll leave it null
+//                tailEntity.getDetails(),
+//                tailEntity.getLevel() != null ? tailEntity.getLevel().getName() : null,
+//                tailEntity.getType() != null ? tailEntity.getType().getName() : null,
+//                tailEntity.getStatus() != null ? tailEntity.getStatus().getName() : null,
+//                null, // metadata is not in TailEntity
+//                tailEntity.getOrganization() != null ? tailEntity.getOrganization().getId() : null
+//        );
+//    }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
@@ -1,0 +1,109 @@
+package com.n1netails.n1netails.api.controller;
+
+import com.n1netails.n1netails.api.exception.type.TailAlreadyBookmarkedException;
+import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
+import com.n1netails.n1netails.api.exception.type.UnauthorizedException;
+import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.entity.TailEntity;
+import com.n1netails.n1netails.api.model.response.TailResponse;
+import com.n1netails.n1netails.api.service.AuthorizationService;
+import com.n1netails.n1netails.api.service.TailBookmarkService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
+
+@RestController
+@RequestMapping("/api/bookmarks")
+@RequiredArgsConstructor
+@Tag(name = "Tail Bookmark Controller", description = "Operations related to tail bookmarks")
+@SecurityRequirement(name = "bearerAuth")
+public class TailBookmarkController {
+
+    private final TailBookmarkService tailBookmarkService;
+    private final AuthorizationService authorizationService;
+
+    @Operation(summary = "Bookmark a tail", responses = {
+            @ApiResponse(responseCode = "200", description = "Tail bookmarked successfully"),
+            @ApiResponse(responseCode = "404", description = "Tail or user not found"),
+            @ApiResponse(responseCode = "409", description = "Tail already bookmarked")
+    })
+    @PostMapping("/{tailId}")
+    public ResponseEntity<Void> bookmarkTail(@PathVariable Long tailId,
+                                             @RequestHeader("Authorization") String authorizationHeader)
+            throws UserNotFoundException, TailNotFoundException, TailAlreadyBookmarkedException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        tailBookmarkService.bookmarkTail(currentUser.getId(), tailId);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "Remove a bookmark from a tail", responses = {
+            @ApiResponse(responseCode = "204", description = "Bookmark removed successfully"),
+            @ApiResponse(responseCode = "404", description = "Tail or user not found")
+    })
+    @DeleteMapping("/{tailId}")
+    public ResponseEntity<Void> removeBookmark(@PathVariable Long tailId,
+                                               @RequestHeader("Authorization") String authorizationHeader)
+            throws UserNotFoundException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        tailBookmarkService.removeBookmark(currentUser.getId(), tailId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Get all bookmarked tails for the current user", responses = {
+            @ApiResponse(responseCode = "200", description = "List of bookmarked tails"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
+    @GetMapping
+    public ResponseEntity<List<TailResponse>> getUserBookmarks(@RequestHeader("Authorization") String authorizationHeader)
+            throws UserNotFoundException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        List<TailEntity> bookmarks = tailBookmarkService.getUserBookmarks(currentUser.getId());
+        List<TailResponse> response = bookmarks.stream()
+                .map(this::toTailResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Check if a tail is bookmarked by the current user", responses = {
+            @ApiResponse(responseCode = "200", description = "Bookmark status"),
+            @ApiResponse(responseCode = "404", description = "User not found")
+    })
+    @GetMapping("/{tailId}/exists")
+    public ResponseEntity<Map<String, Boolean>> isBookmarked(@PathVariable Long tailId,
+                                                             @RequestHeader("Authorization") String authorizationHeader)
+            throws UserNotFoundException, UnauthorizedException {
+        UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
+        boolean isBookmarked = tailBookmarkService.isBookmarked(currentUser.getId(), tailId);
+        return ResponseEntity.ok(Collections.singletonMap("isBookmarked", isBookmarked));
+    }
+
+    private TailResponse toTailResponse(TailEntity tailEntity) {
+        return new TailResponse(
+                tailEntity.getId(),
+                tailEntity.getTitle(),
+                tailEntity.getDescription(),
+                tailEntity.getTimestamp(),
+                tailEntity.getResolvedTimestamp(),
+                tailEntity.getAssignedUserId(),
+                null, // assignedUsername is not in TailEntity, so I'll leave it null
+                tailEntity.getDetails(),
+                tailEntity.getLevel() != null ? tailEntity.getLevel().getName() : null,
+                tailEntity.getType() != null ? tailEntity.getType().getName() : null,
+                tailEntity.getStatus() != null ? tailEntity.getStatus().getName() : null,
+                null, // metadata is not in TailEntity
+                tailEntity.getOrganization() != null ? tailEntity.getOrganization().getId() : null
+        );
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
@@ -2,7 +2,6 @@ package com.n1netails.n1netails.api.controller;
 
 import com.n1netails.n1netails.api.exception.type.*;
 import com.n1netails.n1netails.api.model.UserPrincipal;
-import com.n1netails.n1netails.api.model.entity.TailEntity;
 import com.n1netails.n1netails.api.model.request.TailPageRequest;
 import com.n1netails.n1netails.api.model.response.IsBookmarkedResponse;
 import com.n1netails.n1netails.api.model.response.TailResponse;
@@ -17,12 +16,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
 
 @RestController
 @RequestMapping("/ninetails/bookmarks")
@@ -70,10 +63,6 @@ public class TailBookmarkController {
             throws UserNotFoundException, UnauthorizedException, TailTypeNotFoundException, TailLevelNotFoundException, TailStatusNotFoundException {
         UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         Page<TailResponse> bookmarks = tailBookmarkService.getUserBookmarks(request, currentUser);
-        // todo handle page request
-//        List<TailResponse> response = bookmarks.stream()
-//                .map(this::toTailResponse)
-//                .collect(Collectors.toList());
         return ResponseEntity.ok(bookmarks);
     }
 
@@ -91,22 +80,4 @@ public class TailBookmarkController {
         isBookmarkedResponse.setBookmarked(isBookmarked);
         return ResponseEntity.ok(isBookmarkedResponse);
     }
-
-//    private TailResponse toTailResponse(TailEntity tailEntity) {
-//        return new TailResponse(
-//                tailEntity.getId(),
-//                tailEntity.getTitle(),
-//                tailEntity.getDescription(),
-//                tailEntity.getTimestamp(),
-//                tailEntity.getResolvedTimestamp(),
-//                tailEntity.getAssignedUserId(),
-//                null, // assignedUsername is not in TailEntity, so I'll leave it null
-//                tailEntity.getDetails(),
-//                tailEntity.getLevel() != null ? tailEntity.getLevel().getName() : null,
-//                tailEntity.getType() != null ? tailEntity.getType().getName() : null,
-//                tailEntity.getStatus() != null ? tailEntity.getStatus().getName() : null,
-//                null, // metadata is not in TailEntity
-//                tailEntity.getOrganization() != null ? tailEntity.getOrganization().getId() : null
-//        );
-//    }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
@@ -6,6 +6,7 @@ import com.n1netails.n1netails.api.exception.type.UnauthorizedException;
 import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
 import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.entity.TailEntity;
+import com.n1netails.n1netails.api.model.response.IsBookmarkedResponse;
 import com.n1netails.n1netails.api.model.response.TailResponse;
 import com.n1netails.n1netails.api.service.AuthorizationService;
 import com.n1netails.n1netails.api.service.TailBookmarkService;
@@ -81,12 +82,14 @@ public class TailBookmarkController {
             @ApiResponse(responseCode = "404", description = "User not found")
     })
     @GetMapping("/{tailId}/exists")
-    public ResponseEntity<Map<String, Boolean>> isBookmarked(@PathVariable Long tailId,
+    public ResponseEntity<IsBookmarkedResponse> isBookmarked(@PathVariable Long tailId,
                                                              @RequestHeader("Authorization") String authorizationHeader)
             throws UserNotFoundException, UnauthorizedException {
         UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(authorizationHeader);
         boolean isBookmarked = tailBookmarkService.isBookmarked(currentUser.getId(), tailId);
-        return ResponseEntity.ok(Collections.singletonMap("isBookmarked", isBookmarked));
+        IsBookmarkedResponse isBookmarkedResponse = new IsBookmarkedResponse();
+        isBookmarkedResponse.setBookmarked(isBookmarked);
+        return ResponseEntity.ok(isBookmarkedResponse);
     }
 
     private TailResponse toTailResponse(TailEntity tailEntity) {

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/controller/TailBookmarkController.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import static com.n1netails.n1netails.api.constant.ControllerConstant.APPLICATION_JSON;
 
 @RestController
-@RequestMapping("/api/bookmarks")
+@RequestMapping("/ninetails/bookmarks")
 @RequiredArgsConstructor
 @Tag(name = "Tail Bookmark Controller", description = "Operations related to tail bookmarks")
 @SecurityRequirement(name = "bearerAuth")

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/ExceptionController.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/ExceptionController.java
@@ -75,7 +75,8 @@ public class ExceptionController implements ErrorController {
     @ExceptionHandler({
             EmailExistException.class,
             N1NoteAlreadyExistsException.class,
-            PreviousPasswordMatchException.class
+            PreviousPasswordMatchException.class,
+            TailAlreadyBookmarkedException.class
     })
     public ResponseEntity<HttpErrorResponse> conflictException(Exception exception) {
         log.error(exception.getMessage());

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/type/TailAlreadyBookmarkedException.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/exception/type/TailAlreadyBookmarkedException.java
@@ -1,0 +1,7 @@
+package com.n1netails.n1netails.api.exception.type;
+
+public class TailAlreadyBookmarkedException extends RuntimeException {
+    public TailAlreadyBookmarkedException(String message) {
+        super(message);
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/TailBookmarkEntity.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/entity/TailBookmarkEntity.java
@@ -1,0 +1,37 @@
+package com.n1netails.n1netails.api.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tail_bookmark", schema = "ntail", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "tail_id"})
+})
+public class TailBookmarkEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tail_bookmark_seq")
+    @SequenceGenerator(name = "tail_bookmark_seq", sequenceName = "tail_bookmark_seq", allocationSize = 1)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UsersEntity user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tail_id", nullable = false)
+    private TailEntity tail;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/IsBookmarkedResponse.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/model/response/IsBookmarkedResponse.java
@@ -1,0 +1,14 @@
+package com.n1netails.n1netails.api.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class IsBookmarkedResponse {
+    boolean isBookmarked;
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailBookmarkRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailBookmarkRepository.java
@@ -1,0 +1,22 @@
+package com.n1netails.n1netails.api.repository;
+
+import com.n1netails.n1netails.api.model.entity.TailBookmarkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TailBookmarkRepository extends JpaRepository<TailBookmarkEntity, Long> {
+
+    Optional<TailBookmarkEntity> findByUserIdAndTailId(Long userId, Long tailId);
+
+    List<TailBookmarkEntity> findByUserId(Long userId);
+
+    boolean existsByUserIdAndTailId(Long userId, Long tailId);
+
+    @Transactional
+    void deleteByUserIdAndTailId(Long userId, Long tailId);
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailBookmarkRepository.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/repository/TailBookmarkRepository.java
@@ -1,7 +1,12 @@
 package com.n1netails.n1netails.api.repository;
 
+import com.n1netails.n1netails.api.model.dto.TailSummary;
 import com.n1netails.n1netails.api.model.entity.TailBookmarkEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +19,39 @@ public interface TailBookmarkRepository extends JpaRepository<TailBookmarkEntity
     Optional<TailBookmarkEntity> findByUserIdAndTailId(Long userId, Long tailId);
 
     List<TailBookmarkEntity> findByUserId(Long userId);
+
+    @Query("""
+        SELECT new com.n1netails.n1netails.api.model.dto.TailSummary(
+            t.id,
+            t.title,
+            t.description,
+            t.timestamp,
+            t.resolvedTimestamp,
+            t.assignedUserId,
+            l.name,
+            ty.name,
+            s.name
+        )
+        FROM TailEntity t
+        JOIN t.level l
+        JOIN t.type ty
+        JOIN t.status s
+        JOIN TailBookmarkEntity tb ON tb.tail = t
+        WHERE s.name IN :statuses
+        AND ty.name IN :types
+        AND l.name IN :levels
+        AND (t.title LIKE %:searchTerm% OR t.description LIKE %:searchTerm%)
+        AND tb.user.id = :userId
+        ORDER BY t.timestamp DESC
+    """)
+    Page<TailSummary> findAllBookmarksBySearchTermAndTailFilters(
+            @Param("searchTerm") String searchTerm,
+            @Param("statuses") List<String> statuses,
+            @Param("types") List<String> types,
+            @Param("levels") List<String> levels,
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 
     boolean existsByUserIdAndTailId(Long userId, Long tailId);
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailBookmarkService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailBookmarkService.java
@@ -1,0 +1,20 @@
+package com.n1netails.n1netails.api.service;
+
+import com.n1netails.n1netails.api.exception.type.TailAlreadyBookmarkedException;
+import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
+import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.model.entity.TailBookmarkEntity;
+import com.n1netails.n1netails.api.model.entity.TailEntity;
+
+import java.util.List;
+
+public interface TailBookmarkService {
+
+    TailBookmarkEntity bookmarkTail(Long userId, Long tailId) throws UserNotFoundException, TailNotFoundException, TailAlreadyBookmarkedException;
+
+    void removeBookmark(Long userId, Long tailId);
+
+    List<TailEntity> getUserBookmarks(Long userId);
+
+    boolean isBookmarked(Long userId, Long tailId);
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailBookmarkService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailBookmarkService.java
@@ -1,10 +1,12 @@
 package com.n1netails.n1netails.api.service;
 
-import com.n1netails.n1netails.api.exception.type.TailAlreadyBookmarkedException;
-import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
-import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.exception.type.*;
+import com.n1netails.n1netails.api.model.UserPrincipal;
 import com.n1netails.n1netails.api.model.entity.TailBookmarkEntity;
 import com.n1netails.n1netails.api.model.entity.TailEntity;
+import com.n1netails.n1netails.api.model.request.TailPageRequest;
+import com.n1netails.n1netails.api.model.response.TailResponse;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -14,7 +16,7 @@ public interface TailBookmarkService {
 
     void removeBookmark(Long userId, Long tailId);
 
-    List<TailEntity> getUserBookmarks(Long userId);
+    Page<TailResponse> getUserBookmarks(TailPageRequest request, UserPrincipal currentUser) throws TailTypeNotFoundException, TailLevelNotFoundException, TailStatusNotFoundException;
 
     boolean isBookmarked(Long userId, Long tailId);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailService.java
@@ -2,6 +2,7 @@ package com.n1netails.n1netails.api.service;
 
 import com.n1netails.n1netails.api.exception.type.*;
 import com.n1netails.n1netails.api.model.core.TailStatus;
+import com.n1netails.n1netails.api.model.dto.TailSummary;
 import com.n1netails.n1netails.api.model.request.ResolveTailRequest;
 import com.n1netails.n1netails.api.model.request.TailPageRequest;
 import com.n1netails.n1netails.api.model.response.TailResponse;
@@ -13,10 +14,18 @@ import java.util.List;
 public interface TailService {
 
     Page<TailResponse> getTails(TailPageRequest request, UserPrincipal currentUser) throws TailStatusNotFoundException, TailTypeNotFoundException, TailLevelNotFoundException;
+
+    List<String> getTailLevels(TailPageRequest request) throws TailLevelNotFoundException;
+    List<String> getTailTypes(TailPageRequest request) throws TailTypeNotFoundException;
+    List<String> getTailStatuses(TailPageRequest request) throws TailStatusNotFoundException;
+
+
     List<TailResponse> getTop9NewestTails(UserPrincipal currentUser);
     TailResponse getTailById(Long id, UserPrincipal currentUser) throws TailNotFoundException, UnauthorizedException;
 
     TailResponse updateStatus(Long id, TailStatus tailStatus, UserPrincipal currentUser) throws TailNotFoundException, UnauthorizedException;
 
     void markResolved(ResolveTailRequest request, UserPrincipal currentUser) throws TailNotFoundException, TailStatusNotFoundException, UnauthorizedException;
+
+    TailResponse setTailSummaryResponse(TailSummary tailSummary);
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailService.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/TailService.java
@@ -19,7 +19,6 @@ public interface TailService {
     List<String> getTailTypes(TailPageRequest request) throws TailTypeNotFoundException;
     List<String> getTailStatuses(TailPageRequest request) throws TailStatusNotFoundException;
 
-
     List<TailResponse> getTop9NewestTails(UserPrincipal currentUser);
     TailResponse getTailById(Long id, UserPrincipal currentUser) throws TailNotFoundException, UnauthorizedException;
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailBookmarkServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailBookmarkServiceImpl.java
@@ -1,0 +1,66 @@
+package com.n1netails.n1netails.api.service.impl;
+
+import com.n1netails.n1netails.api.exception.type.TailAlreadyBookmarkedException;
+import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
+import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
+import com.n1netails.n1netails.api.model.entity.TailBookmarkEntity;
+import com.n1netails.n1netails.api.model.entity.TailEntity;
+import com.n1netails.n1netails.api.model.entity.UsersEntity;
+import com.n1netails.n1netails.api.repository.TailBookmarkRepository;
+import com.n1netails.n1netails.api.repository.TailRepository;
+import com.n1netails.n1netails.api.repository.UserRepository;
+import com.n1netails.n1netails.api.service.TailBookmarkService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class TailBookmarkServiceImpl implements TailBookmarkService {
+
+    private final TailBookmarkRepository tailBookmarkRepository;
+    private final UserRepository userRepository;
+    private final TailRepository tailRepository;
+
+
+    @Override
+    @Transactional
+    public TailBookmarkEntity bookmarkTail(Long userId, Long tailId) throws UserNotFoundException, TailNotFoundException, TailAlreadyBookmarkedException {
+        if (tailBookmarkRepository.existsByUserIdAndTailId(userId, tailId)) {
+            throw new TailAlreadyBookmarkedException("Tail " + tailId + " is already bookmarked by user " + userId);
+        }
+        UsersEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("User not found with id: " + userId));
+        TailEntity tail = tailRepository.findById(tailId)
+                .orElseThrow(() -> new TailNotFoundException("Tail not found with id: " + tailId));
+
+        TailBookmarkEntity bookmark = new TailBookmarkEntity();
+        bookmark.setUser(user);
+        bookmark.setTail(tail);
+
+        return tailBookmarkRepository.save(bookmark);
+    }
+
+    @Override
+    public void removeBookmark(Long userId, Long tailId) {
+        tailBookmarkRepository.deleteByUserIdAndTailId(userId, tailId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TailEntity> getUserBookmarks(Long userId) {
+        List<TailBookmarkEntity> bookmarks = tailBookmarkRepository.findByUserId(userId);
+        return bookmarks.stream()
+                .map(TailBookmarkEntity::getTail)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isBookmarked(Long userId, Long tailId) {
+        return tailBookmarkRepository.existsByUserIdAndTailId(userId, tailId);
+    }
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailBookmarkServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailBookmarkServiceImpl.java
@@ -1,29 +1,40 @@
 package com.n1netails.n1netails.api.service.impl;
 
-import com.n1netails.n1netails.api.exception.type.TailAlreadyBookmarkedException;
-import com.n1netails.n1netails.api.exception.type.TailNotFoundException;
-import com.n1netails.n1netails.api.exception.type.UserNotFoundException;
-import com.n1netails.n1netails.api.model.entity.TailBookmarkEntity;
-import com.n1netails.n1netails.api.model.entity.TailEntity;
-import com.n1netails.n1netails.api.model.entity.UsersEntity;
-import com.n1netails.n1netails.api.repository.TailBookmarkRepository;
-import com.n1netails.n1netails.api.repository.TailRepository;
-import com.n1netails.n1netails.api.repository.UserRepository;
+import com.n1netails.n1netails.api.exception.type.*;
+import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.dto.TailSummary;
+import com.n1netails.n1netails.api.model.entity.*;
+import com.n1netails.n1netails.api.model.request.TailPageRequest;
+import com.n1netails.n1netails.api.model.response.TailResponse;
+import com.n1netails.n1netails.api.repository.*;
 import com.n1netails.n1netails.api.service.TailBookmarkService;
+import com.n1netails.n1netails.api.service.TailService;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.n1netails.n1netails.api.util.UserUtil.isInN1netailsOrg;
+
+@Slf4j
 @Service
 @AllArgsConstructor
 public class TailBookmarkServiceImpl implements TailBookmarkService {
 
+    private final TailService tailService;
     private final TailBookmarkRepository tailBookmarkRepository;
     private final UserRepository userRepository;
     private final TailRepository tailRepository;
+    private final TailLevelRepository levelRepository;
+    private final TailTypeRepository typeRepository;
+    private final TailStatusRepository statusRepository;
 
 
     @Override
@@ -51,11 +62,102 @@ public class TailBookmarkServiceImpl implements TailBookmarkService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<TailEntity> getUserBookmarks(Long userId) {
-        List<TailBookmarkEntity> bookmarks = tailBookmarkRepository.findByUserId(userId);
-        return bookmarks.stream()
-                .map(TailBookmarkEntity::getTail)
-                .collect(Collectors.toList());
+    public Page<TailResponse> getUserBookmarks(TailPageRequest request, UserPrincipal currentUser) throws TailTypeNotFoundException, TailLevelNotFoundException, TailStatusNotFoundException {
+
+
+        // Authorization logic implemented. Users can only see tails related to their organizations.
+        // If a user is part of the n1netails organization, they can only view their own tails.
+        // UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(); // Removed
+        List<Long> organizationIds = currentUser.getOrganizations().stream().map(OrganizationEntity::getId).toList();
+
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+
+        String searchTerm = request.getSearchTerm() == null || request.getSearchTerm().isEmpty() ? "" : request.getSearchTerm();
+
+        List<String> statuses;
+        if (request.getFilterByStatus() == null || request.getFilterByStatus().isEmpty()) {
+            List<TailStatusEntity> statusEntities = this.statusRepository.findAll();
+            statuses = statusEntities.stream().map(TailStatusEntity::getName).toList();
+        } else {
+            TailStatusEntity tailStatusEntity = this.statusRepository.findTailStatusByName(request.getFilterByStatus())
+                    .orElseThrow(() -> new TailStatusNotFoundException("Requested status name does not exist."));
+            statuses = List.of(tailStatusEntity.getName());
+        }
+        log.info("STATUS NAMES: {}", statuses);
+
+        List<String> types;
+        if (request.getFilterByType() == null || request.getFilterByType().isEmpty()) {
+            List<TailTypeEntity> tailTypeEntities = this.typeRepository.findAll();
+            types = tailTypeEntities.stream().map(TailTypeEntity::getName).toList();
+        } else {
+            TailTypeEntity tailTypeEntity = this.typeRepository.findTailTypeByName(request.getFilterByType())
+                    .orElseThrow(() -> new TailTypeNotFoundException("Requested type name does not exist."));
+            types = List.of(tailTypeEntity.getName());
+        }
+        log.info("TYPE NAMES: {}", types);
+
+        List<String> levels;
+        if (request.getFilterByLevel() == null || request.getFilterByLevel().isEmpty()) {
+            List<TailLevelEntity> tailLevelEntities = this.levelRepository.findAll();
+            levels = tailLevelEntities.stream().map(TailLevelEntity::getName).toList();
+        } else {
+            TailLevelEntity tailLevelEntity = this.levelRepository.findTailLevelByName(request.getFilterByLevel())
+                    .orElseThrow(() -> new TailLevelNotFoundException("Requested level name does not exist."));
+            levels = List.of(tailLevelEntity.getName());
+        }
+        log.info("LEVEL NAMES: {}", levels);
+
+//        boolean isN1netails = isInN1netailsOrg(currentUser);
+
+        Page<TailSummary> tailBookmarkPage;
+
+        if (currentUser.getId() == null) {
+            // Handle case where user ID is null for n1netails user, perhaps throw exception or return empty page
+            log.warn("User ID is null for n1netails user: {}", currentUser.getUsername());
+            return Page.empty(pageable);
+        }
+
+        tailBookmarkPage = tailBookmarkRepository.findAllBookmarksBySearchTermAndTailFilters(
+          searchTerm,
+          statuses,
+          types,
+          levels,
+          currentUser.getId(),
+          pageable
+        );
+
+        return tailBookmarkPage.map(this::setTailSummaryResponse);
+
+
+
+        //        // todo handle page request
+//        // load tails by search filter then only display bookmarked tails
+//
+//        // todo this need to go first before this.tailService.getTails
+//        List<TailBookmarkEntity> bookmarks = tailBookmarkRepository.findByUserId(currentUser.getId());
+//
+//        List<TailEntity> bookmarksTailEntity = bookmarks.stream()
+//                .map(TailBookmarkEntity::getTail)
+//                .toList();
+//        List<TailResponse> bookmarksTailResponse = bookmarksTailEntity.stream()
+//                .map(this::toTailResponse)
+//                .toList();
+//
+//
+//        Page<TailResponse> pagedTails = this.tailService.getTails(request, currentUser);
+//
+//        // todo implement filter to remove data that is not bookmarked
+//
+////        Page<TailResponse> bookmarkedPagedTails = pagedTails.stream()
+////                .filter(tail -> tail.getId() == )
+////                .toList();
+//
+//        return null;
+//
+//        // todo filter out tails that are not bookmarked
+////        return bookmarks.stream()
+////                .map(TailBookmarkEntity::getTail)
+////                .collect(Collectors.toList());
     }
 
     @Override
@@ -63,4 +165,39 @@ public class TailBookmarkServiceImpl implements TailBookmarkService {
     public boolean isBookmarked(Long userId, Long tailId) {
         return tailBookmarkRepository.existsByUserIdAndTailId(userId, tailId);
     }
+
+    private TailResponse setTailSummaryResponse(TailSummary tailSummary) {
+        TailResponse tailResponse  = new TailResponse();
+        tailResponse.setId(tailSummary.getId());
+        tailResponse.setTitle(tailSummary.getTitle());
+        tailResponse.setDescription(tailSummary.getDescription());
+        tailResponse.setTimestamp(tailSummary.getTimestamp());
+        tailResponse.setResolvedTimestamp(tailSummary.getResolvedTimestamp());
+        tailResponse.setAssignedUserId(tailSummary.getAssignedUserId());
+        UsersEntity user = userRepository.findUserById(tailSummary.getAssignedUserId());
+        tailResponse.setAssignedUsername(user.getUsername());
+        tailResponse.setLevel(tailSummary.getLevel());
+        tailResponse.setType(tailSummary.getType());
+        tailResponse.setStatus(tailSummary.getStatus());
+        return tailResponse;
+    }
+
+    // todo use this to set tail response
+//    private TailResponse toTailResponse(TailEntity tailEntity) {
+//        return new TailResponse(
+//                tailEntity.getId(),
+//                tailEntity.getTitle(),
+//                tailEntity.getDescription(),
+//                tailEntity.getTimestamp(),
+//                tailEntity.getResolvedTimestamp(),
+//                tailEntity.getAssignedUserId(),
+//                null, // assignedUsername is not in TailEntity, so I'll leave it null
+//                tailEntity.getDetails(),
+//                tailEntity.getLevel() != null ? tailEntity.getLevel().getName() : null,
+//                tailEntity.getType() != null ? tailEntity.getType().getName() : null,
+//                tailEntity.getStatus() != null ? tailEntity.getStatus().getName() : null,
+//                null, // metadata is not in TailEntity
+//                tailEntity.getOrganization() != null ? tailEntity.getOrganization().getId() : null
+//        );
+//    }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailBookmarkServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailBookmarkServiceImpl.java
@@ -17,11 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.n1netails.n1netails.api.util.UserUtil.isInN1netailsOrg;
 
 @Slf4j
 @Service
@@ -32,9 +28,6 @@ public class TailBookmarkServiceImpl implements TailBookmarkService {
     private final TailBookmarkRepository tailBookmarkRepository;
     private final UserRepository userRepository;
     private final TailRepository tailRepository;
-    private final TailLevelRepository levelRepository;
-    private final TailTypeRepository typeRepository;
-    private final TailStatusRepository statusRepository;
 
 
     @Override
@@ -64,50 +57,12 @@ public class TailBookmarkServiceImpl implements TailBookmarkService {
     @Transactional(readOnly = true)
     public Page<TailResponse> getUserBookmarks(TailPageRequest request, UserPrincipal currentUser) throws TailTypeNotFoundException, TailLevelNotFoundException, TailStatusNotFoundException {
 
-
-        // Authorization logic implemented. Users can only see tails related to their organizations.
-        // If a user is part of the n1netails organization, they can only view their own tails.
-        // UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(); // Removed
-        List<Long> organizationIds = currentUser.getOrganizations().stream().map(OrganizationEntity::getId).toList();
-
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
-
         String searchTerm = request.getSearchTerm() == null || request.getSearchTerm().isEmpty() ? "" : request.getSearchTerm();
 
-        List<String> statuses;
-        if (request.getFilterByStatus() == null || request.getFilterByStatus().isEmpty()) {
-            List<TailStatusEntity> statusEntities = this.statusRepository.findAll();
-            statuses = statusEntities.stream().map(TailStatusEntity::getName).toList();
-        } else {
-            TailStatusEntity tailStatusEntity = this.statusRepository.findTailStatusByName(request.getFilterByStatus())
-                    .orElseThrow(() -> new TailStatusNotFoundException("Requested status name does not exist."));
-            statuses = List.of(tailStatusEntity.getName());
-        }
-        log.info("STATUS NAMES: {}", statuses);
-
-        List<String> types;
-        if (request.getFilterByType() == null || request.getFilterByType().isEmpty()) {
-            List<TailTypeEntity> tailTypeEntities = this.typeRepository.findAll();
-            types = tailTypeEntities.stream().map(TailTypeEntity::getName).toList();
-        } else {
-            TailTypeEntity tailTypeEntity = this.typeRepository.findTailTypeByName(request.getFilterByType())
-                    .orElseThrow(() -> new TailTypeNotFoundException("Requested type name does not exist."));
-            types = List.of(tailTypeEntity.getName());
-        }
-        log.info("TYPE NAMES: {}", types);
-
-        List<String> levels;
-        if (request.getFilterByLevel() == null || request.getFilterByLevel().isEmpty()) {
-            List<TailLevelEntity> tailLevelEntities = this.levelRepository.findAll();
-            levels = tailLevelEntities.stream().map(TailLevelEntity::getName).toList();
-        } else {
-            TailLevelEntity tailLevelEntity = this.levelRepository.findTailLevelByName(request.getFilterByLevel())
-                    .orElseThrow(() -> new TailLevelNotFoundException("Requested level name does not exist."));
-            levels = List.of(tailLevelEntity.getName());
-        }
-        log.info("LEVEL NAMES: {}", levels);
-
-//        boolean isN1netails = isInN1netailsOrg(currentUser);
+        List<String> statuses = tailService.getTailStatuses(request);
+        List<String> types = tailService.getTailTypes(request);
+        List<String> levels = tailService.getTailLevels(request);
 
         Page<TailSummary> tailBookmarkPage;
 
@@ -126,38 +81,7 @@ public class TailBookmarkServiceImpl implements TailBookmarkService {
           pageable
         );
 
-        return tailBookmarkPage.map(this::setTailSummaryResponse);
-
-
-
-        //        // todo handle page request
-//        // load tails by search filter then only display bookmarked tails
-//
-//        // todo this need to go first before this.tailService.getTails
-//        List<TailBookmarkEntity> bookmarks = tailBookmarkRepository.findByUserId(currentUser.getId());
-//
-//        List<TailEntity> bookmarksTailEntity = bookmarks.stream()
-//                .map(TailBookmarkEntity::getTail)
-//                .toList();
-//        List<TailResponse> bookmarksTailResponse = bookmarksTailEntity.stream()
-//                .map(this::toTailResponse)
-//                .toList();
-//
-//
-//        Page<TailResponse> pagedTails = this.tailService.getTails(request, currentUser);
-//
-//        // todo implement filter to remove data that is not bookmarked
-//
-////        Page<TailResponse> bookmarkedPagedTails = pagedTails.stream()
-////                .filter(tail -> tail.getId() == )
-////                .toList();
-//
-//        return null;
-//
-//        // todo filter out tails that are not bookmarked
-////        return bookmarks.stream()
-////                .map(TailBookmarkEntity::getTail)
-////                .collect(Collectors.toList());
+        return tailBookmarkPage.map(tailService::setTailSummaryResponse);
     }
 
     @Override
@@ -165,39 +89,4 @@ public class TailBookmarkServiceImpl implements TailBookmarkService {
     public boolean isBookmarked(Long userId, Long tailId) {
         return tailBookmarkRepository.existsByUserIdAndTailId(userId, tailId);
     }
-
-    private TailResponse setTailSummaryResponse(TailSummary tailSummary) {
-        TailResponse tailResponse  = new TailResponse();
-        tailResponse.setId(tailSummary.getId());
-        tailResponse.setTitle(tailSummary.getTitle());
-        tailResponse.setDescription(tailSummary.getDescription());
-        tailResponse.setTimestamp(tailSummary.getTimestamp());
-        tailResponse.setResolvedTimestamp(tailSummary.getResolvedTimestamp());
-        tailResponse.setAssignedUserId(tailSummary.getAssignedUserId());
-        UsersEntity user = userRepository.findUserById(tailSummary.getAssignedUserId());
-        tailResponse.setAssignedUsername(user.getUsername());
-        tailResponse.setLevel(tailSummary.getLevel());
-        tailResponse.setType(tailSummary.getType());
-        tailResponse.setStatus(tailSummary.getStatus());
-        return tailResponse;
-    }
-
-    // todo use this to set tail response
-//    private TailResponse toTailResponse(TailEntity tailEntity) {
-//        return new TailResponse(
-//                tailEntity.getId(),
-//                tailEntity.getTitle(),
-//                tailEntity.getDescription(),
-//                tailEntity.getTimestamp(),
-//                tailEntity.getResolvedTimestamp(),
-//                tailEntity.getAssignedUserId(),
-//                null, // assignedUsername is not in TailEntity, so I'll leave it null
-//                tailEntity.getDetails(),
-//                tailEntity.getLevel() != null ? tailEntity.getLevel().getName() : null,
-//                tailEntity.getType() != null ? tailEntity.getType().getName() : null,
-//                tailEntity.getStatus() != null ? tailEntity.getStatus().getName() : null,
-//                null, // metadata is not in TailEntity
-//                tailEntity.getOrganization() != null ? tailEntity.getOrganization().getId() : null
-//        );
-//    }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailServiceImpl.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.n1netails.n1netails.api.util.UserUtil.isInN1netailsOrg;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -292,12 +294,12 @@ public class TailServiceImpl implements TailService {
         return tailResponseList;
     }
 
-    private static boolean isInN1netailsOrg(UserPrincipal currentUser) {
-        boolean isN1netails = currentUser.getOrganizations().stream()
-                .map(OrganizationEntity::getName)
-                .anyMatch(N1NETAILS_ORG::equals);
-        return isN1netails;
-    }
+//    private static boolean isInN1netailsOrg(UserPrincipal currentUser) {
+//        boolean isN1netails = currentUser.getOrganizations().stream()
+//                .map(OrganizationEntity::getName)
+//                .anyMatch(N1NETAILS_ORG::equals);
+//        return isN1netails;
+//    }
 
     private TailResponse setTailSummaryResponse(TailSummary tailSummary) {
         TailResponse tailResponse  = new TailResponse();

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailServiceImpl.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.n1netails.n1netails.api.util.UserUtil.isInN1netailsOrg;
 
 @Slf4j
 @Service
@@ -294,12 +293,12 @@ public class TailServiceImpl implements TailService {
         return tailResponseList;
     }
 
-//    private static boolean isInN1netailsOrg(UserPrincipal currentUser) {
-//        boolean isN1netails = currentUser.getOrganizations().stream()
-//                .map(OrganizationEntity::getName)
-//                .anyMatch(N1NETAILS_ORG::equals);
-//        return isN1netails;
-//    }
+    private static boolean isInN1netailsOrg(UserPrincipal currentUser) {
+        boolean isN1netails = currentUser.getOrganizations().stream()
+                .map(OrganizationEntity::getName)
+                .anyMatch(N1NETAILS_ORG::equals);
+        return isN1netails;
+    }
 
     private TailResponse setTailSummaryResponse(TailSummary tailSummary) {
         TailResponse tailResponse  = new TailResponse();

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/impl/TailServiceImpl.java
@@ -184,43 +184,12 @@ public class TailServiceImpl implements TailService {
         // If a user is part of the n1netails organization, they can only view their own tails.
         // UserPrincipal currentUser = authorizationService.getCurrentUserPrincipal(); // Removed
         List<Long> organizationIds = currentUser.getOrganizations().stream().map(OrganizationEntity::getId).toList();
-
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
-
         String searchTerm = request.getSearchTerm() == null || request.getSearchTerm().isEmpty() ? "" : request.getSearchTerm();
 
-        List<String> statuses;
-        if (request.getFilterByStatus() == null || request.getFilterByStatus().isEmpty()) {
-            List<TailStatusEntity> statusEntities = this.statusRepository.findAll();
-            statuses = statusEntities.stream().map(TailStatusEntity::getName).toList();
-        } else {
-            TailStatusEntity tailStatusEntity = this.statusRepository.findTailStatusByName(request.getFilterByStatus())
-                    .orElseThrow(() -> new TailStatusNotFoundException("Requested status name does not exist."));
-            statuses = List.of(tailStatusEntity.getName());
-        }
-        log.info("STATUS NAMES: {}", statuses);
-
-        List<String> types;
-        if (request.getFilterByType() == null || request.getFilterByType().isEmpty()) {
-            List<TailTypeEntity> tailTypeEntities = this.typeRepository.findAll();
-            types = tailTypeEntities.stream().map(TailTypeEntity::getName).toList();
-        } else {
-            TailTypeEntity tailTypeEntity = this.typeRepository.findTailTypeByName(request.getFilterByType())
-                    .orElseThrow(() -> new TailTypeNotFoundException("Requested type name does not exist."));
-            types = List.of(tailTypeEntity.getName());
-        }
-        log.info("TYPE NAMES: {}", types);
-
-        List<String> levels;
-        if (request.getFilterByLevel() == null || request.getFilterByLevel().isEmpty()) {
-            List<TailLevelEntity> tailLevelEntities = this.levelRepository.findAll();
-            levels = tailLevelEntities.stream().map(TailLevelEntity::getName).toList();
-        } else {
-            TailLevelEntity tailLevelEntity = this.levelRepository.findTailLevelByName(request.getFilterByLevel())
-                    .orElseThrow(() -> new TailLevelNotFoundException("Requested level name does not exist."));
-            levels = List.of(tailLevelEntity.getName());
-        }
-        log.info("LEVEL NAMES: {}", levels);
+        List<String> statuses = this.getTailStatuses(request);
+        List<String> types = this.getTailTypes(request);
+        List<String> levels = this.getTailLevels(request);
 
         boolean isN1netails = isInN1netailsOrg(currentUser);
 
@@ -257,6 +226,51 @@ public class TailServiceImpl implements TailService {
         }
 
         return tailPage.map(this::setTailSummaryResponse);
+    }
+
+    @Override
+    public List<String> getTailLevels(TailPageRequest request) throws TailLevelNotFoundException {
+        List<String> levels;
+        if (request.getFilterByLevel() == null || request.getFilterByLevel().isEmpty()) {
+            List<TailLevelEntity> tailLevelEntities = this.levelRepository.findAll();
+            levels = tailLevelEntities.stream().map(TailLevelEntity::getName).toList();
+        } else {
+            TailLevelEntity tailLevelEntity = this.levelRepository.findTailLevelByName(request.getFilterByLevel())
+                    .orElseThrow(() -> new TailLevelNotFoundException("Requested level name does not exist."));
+            levels = List.of(tailLevelEntity.getName());
+        }
+        log.info("LEVEL NAMES: {}", levels);
+        return levels;
+    }
+
+    @Override
+    public List<String> getTailTypes(TailPageRequest request) throws TailTypeNotFoundException {
+        List<String> types;
+        if (request.getFilterByType() == null || request.getFilterByType().isEmpty()) {
+            List<TailTypeEntity> tailTypeEntities = this.typeRepository.findAll();
+            types = tailTypeEntities.stream().map(TailTypeEntity::getName).toList();
+        } else {
+            TailTypeEntity tailTypeEntity = this.typeRepository.findTailTypeByName(request.getFilterByType())
+                    .orElseThrow(() -> new TailTypeNotFoundException("Requested type name does not exist."));
+            types = List.of(tailTypeEntity.getName());
+        }
+        log.info("TYPE NAMES: {}", types);
+        return types;
+    }
+
+    @Override
+    public List<String> getTailStatuses(TailPageRequest request) throws TailStatusNotFoundException {
+        List<String> statuses;
+        if (request.getFilterByStatus() == null || request.getFilterByStatus().isEmpty()) {
+            List<TailStatusEntity> statusEntities = this.statusRepository.findAll();
+            statuses = statusEntities.stream().map(TailStatusEntity::getName).toList();
+        } else {
+            TailStatusEntity tailStatusEntity = this.statusRepository.findTailStatusByName(request.getFilterByStatus())
+                    .orElseThrow(() -> new TailStatusNotFoundException("Requested status name does not exist."));
+            statuses = List.of(tailStatusEntity.getName());
+        }
+        log.info("STATUS NAMES: {}", statuses);
+        return statuses;
     }
 
     @Override
@@ -300,7 +314,8 @@ public class TailServiceImpl implements TailService {
         return isN1netails;
     }
 
-    private TailResponse setTailSummaryResponse(TailSummary tailSummary) {
+    @Override
+    public TailResponse setTailSummaryResponse(TailSummary tailSummary) {
         TailResponse tailResponse  = new TailResponse();
         tailResponse.setId(tailSummary.getId());
         tailResponse.setTitle(tailSummary.getTitle());

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/util/UserUtil.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/util/UserUtil.java
@@ -1,24 +1,12 @@
 package com.n1netails.n1netails.api.util;
 
 import java.util.UUID;
-
-import com.n1netails.n1netails.api.model.UserPrincipal;
-import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
 import lombok.extern.slf4j.Slf4j;
-
-import static com.n1netails.n1netails.api.service.impl.TailServiceImpl.N1NETAILS_ORG;
 
 @Slf4j
 public class UserUtil {
 
     public static String generateUserId() {
         return UUID.randomUUID().toString();
-    }
-
-    public static boolean isInN1netailsOrg(UserPrincipal currentUser) {
-        boolean isN1netails = currentUser.getOrganizations().stream()
-                .map(OrganizationEntity::getName)
-                .anyMatch(N1NETAILS_ORG::equals);
-        return isN1netails;
     }
 }

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/util/UserUtil.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/util/UserUtil.java
@@ -1,12 +1,24 @@
 package com.n1netails.n1netails.api.util;
 
 import java.util.UUID;
+
+import com.n1netails.n1netails.api.model.UserPrincipal;
+import com.n1netails.n1netails.api.model.entity.OrganizationEntity;
 import lombok.extern.slf4j.Slf4j;
+
+import static com.n1netails.n1netails.api.service.impl.TailServiceImpl.N1NETAILS_ORG;
 
 @Slf4j
 public class UserUtil {
 
     public static String generateUserId() {
         return UUID.randomUUID().toString();
+    }
+
+    public static boolean isInN1netailsOrg(UserPrincipal currentUser) {
+        boolean isN1netails = currentUser.getOrganizations().stream()
+                .map(OrganizationEntity::getName)
+                .anyMatch(N1NETAILS_ORG::equals);
+        return isN1netails;
     }
 }

--- a/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-00017-create-table-tail-bookmark.xml
+++ b/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-00017-create-table-tail-bookmark.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet id="00017-create-table-tail-bookmark" author="jules">
+        <sqlFile path="sql/db.changelog-00017-create-table-tail-bookmark.sql" relativeToChangelogFile="true"/>
+        <rollback>
+            <sql>
+                DROP TABLE ntail.tail_bookmark;
+                DROP SEQUENCE ntail.tail_bookmark_seq;
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/n1netails-liquibase/src/main/resources/db/changelog/db.changelog-master.xml
@@ -23,4 +23,5 @@
     <include file="db/changelog/db.changelog-00014-alter-user-id-to-uuid-in-users-table.xml"/>
     <include file="db/changelog/db.changelog-00015-create-forgot-password-request-table.xml"/>
     <include file="db/changelog/db.changelog-00016-insert-forgot-password-mail-template.xml"/>
+    <include file="db/changelog/db.changelog-00017-create-table-tail-bookmark.xml"/>
 </databaseChangeLog>

--- a/n1netails-liquibase/src/main/resources/db/changelog/sql/db.changelog-00017-create-table-tail-bookmark.sql
+++ b/n1netails-liquibase/src/main/resources/db/changelog/sql/db.changelog-00017-create-table-tail-bookmark.sql
@@ -1,0 +1,12 @@
+CREATE SEQUENCE ntail.tail_bookmark_seq;
+
+CREATE TABLE ntail.tail_bookmark (
+    id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    tail_id BIGINT NOT NULL,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    CONSTRAINT pk_tail_bookmark PRIMARY KEY (id),
+    CONSTRAINT fk_tail_bookmark_user FOREIGN KEY (user_id) REFERENCES ntail.users(id),
+    CONSTRAINT fk_tail_bookmark_tail FOREIGN KEY (tail_id) REFERENCES ntail.tail(id),
+    CONSTRAINT uq_user_tail UNIQUE (user_id, tail_id)
+);

--- a/n1netails-ui/src/main/typescript/package-lock.json
+++ b/n1netails-ui/src/main/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typescript",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typescript",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "dependencies": {
         "@angular/common": "^19.2.0",
         "@angular/compiler": "^19.2.0",

--- a/n1netails-ui/src/main/typescript/src/app/model/interface/tail-page.interface.ts
+++ b/n1netails-ui/src/main/typescript/src/app/model/interface/tail-page.interface.ts
@@ -14,16 +14,3 @@ export interface TailPageResponse<T> {
   size: number;
   number: number; // current page number
 }
-
-// export interface Tail {
-//   id: number;
-//   title: string;
-//   description?: string;
-//   timestamp: string; // Assuming ISO date string
-//   status: string;
-//   type: string;
-//   level: string;
-//   assignedUserId?: number;
-//   assignedUsername?: string;
-//   selected: boolean;
-// }

--- a/n1netails-ui/src/main/typescript/src/app/model/interface/tail-page.interface.ts
+++ b/n1netails-ui/src/main/typescript/src/app/model/interface/tail-page.interface.ts
@@ -1,0 +1,29 @@
+export interface TailPageRequest {
+  page: number;
+  size: number;
+  searchTerm?: string;
+  filterByStatus?: string;
+  filterByType?: string;
+  filterByLevel?: string;
+}
+
+export interface TailPageResponse<T> {
+  content: T[];
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  number: number; // current page number
+}
+
+// export interface Tail {
+//   id: number;
+//   title: string;
+//   description?: string;
+//   timestamp: string; // Assuming ISO date string
+//   status: string;
+//   type: string;
+//   level: string;
+//   assignedUserId?: number;
+//   assignedUsername?: string;
+//   selected: boolean;
+// }

--- a/n1netails-ui/src/main/typescript/src/app/model/tail.model.ts
+++ b/n1netails-ui/src/main/typescript/src/app/model/tail.model.ts
@@ -4,7 +4,7 @@ export interface TailResponse {
   description: string;
   timestamp: string;
   resolvedTimestamp: string;
-  assignedUserId: string;
+  assignedUserId: number;
   assignedUsername: string;
   details: string;
   level: string;
@@ -12,6 +12,7 @@ export interface TailResponse {
   status: string;
   metadata: { [key: string]: string };
   organizationId: number;
+  selected: boolean;
 }
 
 export interface TailSummary {

--- a/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.html
@@ -42,7 +42,7 @@
                         nzTheme="outline"/>
                     </button>
 
-                    <button nz-button nzType="primary" (click)="openResolveModal()" *ngIf="tail && tail.status !== 'RESOLVED' && tail.assignedUserId == currentUser.id.toString()">
+                    <button nz-button nzType="primary" (click)="openResolveModal()" *ngIf="tail && tail.status !== 'RESOLVED' && tail.assignedUserId == currentUser.id">
                       Resolve Tail
                     </button>
                     <button nz-button nzType="default" (click)="investigateTail()" *ngIf="llmEnabled && tail && tail.status !== 'RESOLVED' && n1Note.content === ''" [nzLoading]="isInvestigating" [disabled]="!tail || isInvestigating">

--- a/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.html
@@ -29,6 +29,19 @@
 
                   <!-- Modified section for action buttons -->
                   <div class="tail-actions">
+                    <button 
+                      id="bookmark-button"
+                      [class.active]="bookmarkActive"
+                      nzTooltipTitle="Bookmark tail" 
+                      nzType="default"
+                      nzTooltipPlacement="topRight" 
+                      nz-button nz-tooltip
+                      (click)="bookmarkActive = !bookmarkActive">
+                      <nz-icon 
+                        nzType="book" 
+                        nzTheme="outline"/>
+                    </button>
+
                     <button nz-button nzType="primary" (click)="openResolveModal()" *ngIf="tail && tail.status !== 'RESOLVED' && tail.assignedUserId == currentUser.id.toString()">
                       Resolve Tail
                     </button>

--- a/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.html
@@ -36,7 +36,7 @@
                       nzType="default"
                       nzTooltipPlacement="topRight" 
                       nz-button nz-tooltip
-                      (click)="bookmarkActive = !bookmarkActive">
+                      (click)="bookmarkTailEvent(tail.id)">
                       <nz-icon 
                         nzType="book" 
                         nzTheme="outline"/>

--- a/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.less
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.less
@@ -6,6 +6,19 @@ nz-header {
   z-index: 2;
 }
 
+#bookmark-button {
+  background-color: transparent;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 18px;
+
+  &.active nz-icon {
+    color: @primary-color;
+  }
+}
+
 .tail-details-container {
 
   .loading-indicator,

--- a/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.ts
@@ -27,6 +27,7 @@ import { NoteService } from '../../service/note.service';
 import { Note } from '../../model/note.model';
 import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
+import { BookmarkService, IsBookmarkedResponse } from '../../service/bookmark.service';
 
 @Component({
   selector: 'app-tail',
@@ -93,6 +94,7 @@ export class TailComponent implements OnInit {
   private authService = inject(AuthenticationService);
   private llmService = inject(LlmService);
   private noteService = inject(NoteService);
+  private bookmarkService = inject(BookmarkService);
 
   constructor() {
     this.currentUser = this.authService.getUserFromLocalCache();
@@ -113,9 +115,49 @@ export class TailComponent implements OnInit {
         return;
       }
       this.loadTailData(id);
+      this.checkForBookmark(id);
     } else {
       this.error = 'No Tail ID found in URL.';
       this.isLoading = false;
+    }
+  }
+
+  checkForBookmark(id: number) {
+    console.log('checking for bookmark');
+    this.bookmarkService.isTailBookmarkedByUser(id).subscribe({
+      next: (data: IsBookmarkedResponse) => {
+        console.log('is bookmarked by user: ', data);
+        if (data.bookmarked) this.bookmarkActive = true;
+        else this.bookmarkActive = false;
+      },
+      error: (err) => {
+        console.error('Error checking if tail bookmarked by user:', err);
+        this.error = `Failed to check bookmark by user. Status: ${err.status}, message: ${err.message || err}`;
+      }
+    });
+  }
+
+  bookmarkTailEvent(id: number) {
+    if (this.bookmarkActive === false) {
+      this.bookmarkService.bookmarkTail(id).subscribe({
+        next: () => {
+          this.bookmarkActive = true;
+        },
+        error: (err) => {
+          console.error('Error bookmarking tail:', err);
+          this.error = `Failed to bookmark. Status: ${err.status}, message: ${err.message || err}`;
+        }
+      });
+    } else {
+      this.bookmarkService.removeBookmark(id).subscribe({
+        next: () => {
+          this.bookmarkActive = false;
+        },
+        error: (err) => {
+          console.error('Error removing bookmark for tail:', err);
+          this.error = `Failed to remove bookmark. Status: ${err.status}, message: ${err.message || err}`;
+        }
+      })
     }
   }
 

--- a/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tail/tail.component.ts
@@ -25,6 +25,8 @@ import { ResolveTailRequest, TailResponse, TailSummary } from '../../model/tail.
 import { LlmPromptRequest, LlmPromptResponse } from '../../model/llm.model';
 import { NoteService } from '../../service/note.service';
 import { Note } from '../../model/note.model';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 @Component({
   selector: 'app-tail',
@@ -40,6 +42,8 @@ import { Note } from '../../model/note.model';
     NzCardModule,
     NzAvatarModule,
     NzButtonModule,
+    NzIconModule,
+    NzToolTipModule,
     HeaderComponent,
     SidenavComponent,
     ResolveTailModalComponent,
@@ -51,6 +55,8 @@ import { Note } from '../../model/note.model';
 })
 export class TailComponent implements OnInit {
   objectKeys = Object.keys;
+
+  bookmarkActive = false;
 
   tail: TailResponse | null = null;
   metadataKeys: string[] = [];

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.html
@@ -98,7 +98,7 @@
                   <nz-option nzValue="100" nzLabel="100"></nz-option>
                 </nz-select>
 
-                <button nz-button nzType="primary" (click)="onSearchTermChange()"><nz-icon nzType="search" nzTheme="outline" /></button>
+                <button class="tails-button" nz-button nzType="primary" (click)="onSearchTermChange()"><nz-icon nzType="search" nzTheme="outline" /></button>
               </div>
 
               <!-- Ng Zorro Table -->
@@ -158,9 +158,9 @@
               </nz-table>
 
               <div *ngIf="totalPages > 0" class="table-pagination">
-                <button nz-button nzType="default" (click)="previousPage()" [disabled]="currentPage === 0"><nz-icon nzType="left" nzTheme="outline" /></button>
+                <button class="tails-button" nz-button nzType="default" (click)="previousPage()" [disabled]="currentPage === 0"><nz-icon nzType="left" nzTheme="outline" /></button>
                 <span style="margin: 0 12px; color: #f1f1f1;">Page {{ displayedCurrentPage }} of {{ totalPages }}</span>
-                <button nz-button nzType="default" (click)="nextPage()" [disabled]="currentPage >= totalPages - 1"><nz-icon nzType="right" nzTheme="outline" /></button>
+                <button class="tails-button" nz-button nzType="default" (click)="nextPage()" [disabled]="currentPage >= totalPages - 1"><nz-icon nzType="right" nzTheme="outline" /></button>
                 <span style="margin-left: 16px;">Total items: {{ totalElements }}</span>
               </div>
             </nz-card>

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.html
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.html
@@ -24,7 +24,7 @@
                   nzType="default"
                   nzTooltipPlacement="topRight" 
                   nz-button nz-tooltip
-                  (click)="bookmarksActive = !bookmarksActive">
+                  (click)="setBookmarkActive()">
                   <nz-icon 
                     nzType="book" 
                     nzTheme="outline"/>

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.less
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.less
@@ -77,7 +77,7 @@ input[nz-input], .ant-input, .ant-input-affix-wrapper {
   }
 }
 
-#search-button {
+.tails-button {
   background: @primary-color;
   color: #fff;
   border: none;

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { TailDataService, Tail, TailPageRequest, TailPageResponse } from '../../service/tail-data';
+import { TailDataService } from '../../service/tail-data';
 import { NzLayoutModule } from 'ng-zorro-antd/layout';
 import { NzGridModule } from 'ng-zorro-antd/grid';
 import { HeaderComponent } from '../../shared/template/header/header.component';
@@ -23,10 +23,12 @@ import { User } from '../../model/user';
 import { AuthenticationService } from '../../service/authentication.service';
 import { TailService } from '../../service/tail.service';
 import { NzMessageService } from 'ng-zorro-antd/message';
-import { ResolveTailRequest, TailSummary } from '../../model/tail.model';
+import { ResolveTailRequest, TailResponse, TailSummary } from '../../model/tail.model';
 import { PageRequest } from '../../model/interface/page.interface';
 import { PageUtilService } from '../../shared/util/page-util.service';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
+import { BookmarkService } from '../../service/bookmark.service';
+import { TailPageRequest, TailPageResponse } from '../../model/interface/tail-page.interface';
 
 @Component({
   selector: 'app-tails',
@@ -55,7 +57,7 @@ export class TailsComponent implements OnInit {
 
   bookmarksActive = false;
 
-  tails: Tail[] = [];
+  tails: TailResponse[] = [];
   currentPage: number = 0;
   pageSize: number = 10;
   totalElements: number = 0;
@@ -66,7 +68,7 @@ export class TailsComponent implements OnInit {
   selectedType: string = '';   // Bound to type dropdown
   selectedLevel: string = '';  // Bound to level dropdown
 
-  selectedTails: Set<Tail> = new Set();
+  selectedTails: Set<TailResponse> = new Set();
 
   tailLevels: string[] = [];
   tailStatusList: string[] = [];
@@ -84,6 +86,7 @@ export class TailsComponent implements OnInit {
     private tailStatusService: TailStatusService,
     private tailTypeService: TailTypeService,
     private tailService: TailService,
+    private bookmarkService: BookmarkService,
     private authenticationService: AuthenticationService,
     private messageService: NzMessageService,
     private router: Router,
@@ -101,7 +104,12 @@ export class TailsComponent implements OnInit {
     this.router.navigate(['/tail', id]);
   }
 
-  loadTails(): void {
+  setBookmarkActive() {
+    this.bookmarksActive = !this.bookmarksActive
+    this.loadTails();
+  }
+
+  loadTailsDefault(): void {
     const request: TailPageRequest = {
       page: this.currentPage,
       size: this.pageSize,
@@ -112,7 +120,7 @@ export class TailsComponent implements OnInit {
     };
 
     this.tailDataService.getTails(request).subscribe({
-      next: (response: TailPageResponse<Tail>) => {
+      next: (response: TailPageResponse<TailResponse>) => {
         response.content.forEach(tail => {
           tail.selected = false;
           this.tails.push(tail);
@@ -131,6 +139,44 @@ export class TailsComponent implements OnInit {
         this.totalPages = 0;
       }
     });
+  }
+
+  loadTails() {
+    if (!this.bookmarksActive) {
+      this.loadTailsDefault();
+    } else {
+      this.currentPage = 0;
+      const request: TailPageRequest = {
+        page: this.currentPage,
+        size: this.pageSize,
+        searchTerm: this.searchTerm,
+        filterByStatus: this.selectedStatus || undefined,
+        filterByType: this.selectedType || undefined,
+        filterByLevel: this.selectedLevel || undefined
+      };
+
+      this.bookmarkService.getUserTailBookmarks(request).subscribe({
+        next: (response: TailPageResponse<TailResponse>) => {
+          response.content.forEach(tail => {
+            tail.selected = false;
+            this.tails.push(tail);
+          });
+          this.tails = response.content;
+          this.totalElements = response.totalElements;
+          this.totalPages = response.totalPages;
+          if (this.currentPage >= this.totalPages && this.totalPages > 0) {
+            this.currentPage = this.totalPages - 1;
+          }
+        },
+        error: (err) => {
+          console.log('Error loading bookmarked tails:', err);
+          this.tails = [];
+          this.totalElements = 0;
+          this.totalPages = 0;
+          this.bookmarksActive = false;
+        }
+      });
+    }
   }
 
   loadTailInfoData(): void {
@@ -197,7 +243,7 @@ export class TailsComponent implements OnInit {
     }
   }
 
-  toggleSelection(tail: Tail): void {
+  toggleSelection(tail: TailResponse): void {
     if (this.selectedTails.has(tail)) {
       this.selectedTails.delete(tail);
     } else {
@@ -205,7 +251,7 @@ export class TailsComponent implements OnInit {
     }
   }
 
-  isSelected(tail: Tail): boolean {
+  isSelected(tail: TailResponse): boolean {
     return this.selectedTails.has(tail);
   }
 

--- a/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
+++ b/n1netails-ui/src/main/typescript/src/app/pages/tails/tails.ts
@@ -105,6 +105,7 @@ export class TailsComponent implements OnInit {
 
   setBookmarkActive() {
     this.bookmarksActive = !this.bookmarksActive
+    this.currentPage = 0;
     this.loadTails();
   }
 
@@ -144,7 +145,6 @@ export class TailsComponent implements OnInit {
     if (!this.bookmarksActive) {
       this.loadTailsDefault();
     } else {
-      this.currentPage = 0;
       const request: TailPageRequest = {
         page: this.currentPage,
         size: this.pageSize,

--- a/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { UiConfigService } from '../shared/util/ui-config.service';
+import { HttpClient } from '@angular/common/http';
+import { TailResponse } from '../model/tail.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BookmarkService {
+
+  host: string = '';
+  private apiPath = '/ninetails/bookmarks'
+
+  constructor(
+    private http: HttpClient,
+    private uiConfigService: UiConfigService
+  ) {}
+
+  bookmarkTail(tailId: number) {
+    this.host = this.uiConfigService.getApiUrl() + this.apiPath;
+    return this.http.post<void>(`${this.host}/${tailId}`, {});
+  }
+
+  removeBookmark(tailId: number) {
+    this.host = this.uiConfigService.getApiUrl() + this.apiPath;
+    return this.http.delete<void>(`${this.host}/${tailId}`);
+  }
+
+  getUserTailBookmarks() {
+    this.host = this.uiConfigService.getApiUrl() + this.apiPath;
+    return this.http.get<TailResponse[]>(`${this.host}`);
+  }
+
+  isTailBookmarkedByUser(tailId: number) {
+    this.host = this.uiConfigService.getApiUrl() + this.apiPath;
+    return this.http.get<Map<string, boolean>>(`${this.host}/${tailId}/exists`);
+  }
+}

--- a/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
@@ -2,10 +2,33 @@ import { Injectable } from '@angular/core';
 import { UiConfigService } from '../shared/util/ui-config.service';
 import { HttpClient } from '@angular/common/http';
 import { TailResponse } from '../model/tail.model';
+import { Observable } from 'rxjs';
+import { TailPageRequest, TailPageResponse } from '../model/interface/tail-page.interface';
 
 export interface IsBookmarkedResponse {
   bookmarked: boolean;
 }
+
+// export interface TailPageResponse<T> {
+//   content: T[];
+//   totalPages: number;
+//   totalElements: number;
+//   size: number;
+//   number: number; // current page number
+// }
+
+// export interface Tail {
+//   id: number;
+//   title: string;
+//   description?: string;
+//   timestamp: string; // Assuming ISO date string
+//   status: string;
+//   type: string;
+//   level: string;
+//   assignedUserId?: number;
+//   assignedUsername?: string;
+//   selected: boolean;
+// }
 
 @Injectable({
   providedIn: 'root'
@@ -30,9 +53,9 @@ export class BookmarkService {
     return this.http.delete<void>(`${this.host}/${tailId}`);
   }
 
-  getUserTailBookmarks() {
+  getUserTailBookmarks(request: TailPageRequest): Observable<TailPageResponse<TailResponse>> {
     this.host = this.uiConfigService.getApiUrl() + this.apiPath;
-    return this.http.get<TailResponse[]>(`${this.host}`);
+    return this.http.post<TailPageResponse<TailResponse>>(`${this.host}`, request);
   }
 
   isTailBookmarkedByUser(tailId: number) {

--- a/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
@@ -3,6 +3,10 @@ import { UiConfigService } from '../shared/util/ui-config.service';
 import { HttpClient } from '@angular/common/http';
 import { TailResponse } from '../model/tail.model';
 
+export interface IsBookmarkedResponse {
+  bookmarked: boolean;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -33,6 +37,6 @@ export class BookmarkService {
 
   isTailBookmarkedByUser(tailId: number) {
     this.host = this.uiConfigService.getApiUrl() + this.apiPath;
-    return this.http.get<Map<string, boolean>>(`${this.host}/${tailId}/exists`);
+    return this.http.get<IsBookmarkedResponse>(`${this.host}/${tailId}/exists`);
   }
 }

--- a/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/bookmark.service.ts
@@ -9,27 +9,6 @@ export interface IsBookmarkedResponse {
   bookmarked: boolean;
 }
 
-// export interface TailPageResponse<T> {
-//   content: T[];
-//   totalPages: number;
-//   totalElements: number;
-//   size: number;
-//   number: number; // current page number
-// }
-
-// export interface Tail {
-//   id: number;
-//   title: string;
-//   description?: string;
-//   timestamp: string; // Assuming ISO date string
-//   status: string;
-//   type: string;
-//   level: string;
-//   assignedUserId?: number;
-//   assignedUsername?: string;
-//   selected: boolean;
-// }
-
 @Injectable({
   providedIn: 'root'
 })

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-data.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-data.ts
@@ -5,36 +5,6 @@ import { UiConfigService } from '../shared/util/ui-config.service';
 import { TailPageRequest, TailPageResponse } from '../model/interface/tail-page.interface';
 import { TailResponse } from '../model/tail.model';
 
-// export interface TailPageRequest {
-//   page: number;
-//   size: number;
-//   searchTerm?: string;
-//   filterByStatus?: string;
-//   filterByType?: string;
-//   filterByLevel?: string;
-// }
-
-// export interface TailPageResponse<T> {
-//   content: T[];
-//   totalPages: number;
-//   totalElements: number;
-//   size: number;
-//   number: number; // current page number
-// }
-
-// export interface Tail {
-//   id: number;
-//   title: string;
-//   description?: string;
-//   timestamp: string; // Assuming ISO date string
-//   status: string;
-//   type: string;
-//   level: string;
-//   assignedUserId?: number;
-//   assignedUsername?: string;
-//   selected: boolean;
-// }
-
 @Injectable({
   providedIn: 'root'
 })

--- a/n1netails-ui/src/main/typescript/src/app/service/tail-data.ts
+++ b/n1netails-ui/src/main/typescript/src/app/service/tail-data.ts
@@ -2,36 +2,38 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { UiConfigService } from '../shared/util/ui-config.service';
+import { TailPageRequest, TailPageResponse } from '../model/interface/tail-page.interface';
+import { TailResponse } from '../model/tail.model';
 
-export interface TailPageRequest {
-  page: number;
-  size: number;
-  searchTerm?: string;
-  filterByStatus?: string;
-  filterByType?: string;
-  filterByLevel?: string;
-}
+// export interface TailPageRequest {
+//   page: number;
+//   size: number;
+//   searchTerm?: string;
+//   filterByStatus?: string;
+//   filterByType?: string;
+//   filterByLevel?: string;
+// }
 
-export interface TailPageResponse<T> {
-  content: T[];
-  totalPages: number;
-  totalElements: number;
-  size: number;
-  number: number; // current page number
-}
+// export interface TailPageResponse<T> {
+//   content: T[];
+//   totalPages: number;
+//   totalElements: number;
+//   size: number;
+//   number: number; // current page number
+// }
 
-export interface Tail {
-  id: number;
-  title: string;
-  description?: string;
-  timestamp: string; // Assuming ISO date string
-  status: string;
-  type: string;
-  level: string;
-  assignedUserId?: number;
-  assignedUsername?: string;
-  selected: boolean;
-}
+// export interface Tail {
+//   id: number;
+//   title: string;
+//   description?: string;
+//   timestamp: string; // Assuming ISO date string
+//   status: string;
+//   type: string;
+//   level: string;
+//   assignedUserId?: number;
+//   assignedUsername?: string;
+//   selected: boolean;
+// }
 
 @Injectable({
   providedIn: 'root'
@@ -46,8 +48,8 @@ export class TailDataService {
     private uiConfigService: UiConfigService
   ) {}
 
-  getTails(request: TailPageRequest): Observable<TailPageResponse<Tail>> {
+  getTails(request: TailPageRequest): Observable<TailPageResponse<TailResponse>> {
     this.host = this.uiConfigService.getApiUrl() + this.apiPath;
-    return this.http.post<TailPageResponse<Tail>>(`${this.host}/page`, request);
+    return this.http.post<TailPageResponse<TailResponse>>(`${this.host}/page`, request);
   }
 }


### PR DESCRIPTION
This commit introduces a new feature that allows users to bookmark tails.

The implementation includes:
- A new `TailBookmarkEntity` to store the many-to-many relationship between users and tails.
- A `TailBookmarkRepository` for database operations.
- A `TailBookmarkService` for the business logic of bookmarking.
- A `TailBookmarkController` to expose the functionality via a REST API with the following endpoints:
  - `POST /api/bookmarks/{tailId}` to bookmark a tail.
  - `DELETE /api/bookmarks/{tailId}` to remove a bookmark.
  - `GET /api/bookmarks` to list the current user's bookmarked tails.
  - `GET /api/bookmarks/{tailId}/exists` to check if a tail is bookmarked.
- A new exception `TailAlreadyBookmarkedException`.
- Liquibase changelogs to create the `tail_bookmark` table and its sequence.

I also addressed feedback from the code review by:
- Adding `@Transactional` to the `deleteByUserIdAndTailId` method in the repository.
- Removing a redundant existence check in the service layer before deleting a bookmark.
- Cleaning up duplicated imports in the controller.