### PR TITLE
improved discord notification colors for each tail level

### DIFF
--- a/n1netails-api/pom.xml
+++ b/n1netails-api/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>com.n1netails</groupId>
 	<artifactId>n1netails-api</artifactId>
-	<version>0.3.14</version>
+	<version>0.3.15</version>
 	<name>n1netails-api</name>
 	<description>N1netails Alert Service API</description>
 

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/constant/TailLevelConstant.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/constant/TailLevelConstant.java
@@ -1,0 +1,9 @@
+package com.n1netails.n1netails.api.constant;
+
+public class TailLevelConstant {
+    public static final String INFO = "INFO";
+    public static final String SUCCESS = "SUCCESS";
+    public static final String WARN = "WARN";
+    public static final String ERROR = "ERROR";
+    public static final String CRITICAL = "CRITICAL";
+}

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/platform/DiscordNotificationServiceImpl.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/service/platform/DiscordNotificationServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.n1netails.n1netails.api.constant.PlatformConstant.DISCORD;
+import static com.n1netails.n1netails.api.constant.TailLevelConstant.*;
 
 @Slf4j
 @Service
@@ -88,11 +89,20 @@ public class DiscordNotificationServiceImpl implements NotificationPlatform {
         footer.setIcon_url("https://raw.githubusercontent.com/n1netails/n1netails/refs/heads/main/n1netails_icon_transparent.png");
         String description = request.getDescription();
 
+        String tailLevelDiscordColor = switch (request.getLevel().toUpperCase()) {
+            case INFO -> DiscordColor.BLUE.getValue();
+            case SUCCESS -> DiscordColor.GREEN.getValue();
+            case WARN -> DiscordColor.GOLD.getValue();
+            case ERROR -> DiscordColor.ORANGE.getValue();
+            case CRITICAL -> DiscordColor.RED.getValue();
+            default -> DiscordColor.DARK_RED.getValue();
+        };
+
         Embed embed = new EmbedBuilder()
                 .withTitle("View Notification")
                 .withDescription(description)
                 .withUrl(ui)
-                .withColor(DiscordColor.ORANGE.getValue())
+                .withColor(tailLevelDiscordColor)
                 .withAuthor(author)
                 .withFields(fields)
                 .withFooter(footer)

--- a/n1netails-api/src/main/java/com/n1netails/n1netails/api/util/EmojiUtil.java
+++ b/n1netails-api/src/main/java/com/n1netails/n1netails/api/util/EmojiUtil.java
@@ -2,6 +2,8 @@ package com.n1netails.n1netails.api.util;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static com.n1netails.n1netails.api.constant.TailLevelConstant.*;
+
 @Slf4j
 public class EmojiUtil {
 
@@ -20,11 +22,11 @@ public class EmojiUtil {
      */
     public static String getTailLevelEmoji(String tailLevel) {
         return switch (tailLevel) {
-            case "INFO" -> "\uD83D\uDCA1 "; // 💡 info
-            case "SUCCESS" -> "✅ "; // ✅ success
-            case "WARN" -> "⚠\uFE0F "; // ⚠️ warn
-            case "ERROR" -> "❌ "; // ❌ error
-            case "CRITICAL" -> "\uD83D\uDEA8 "; // 🚨 critical
+            case INFO -> "\uD83D\uDCA1 "; // 💡 info
+            case SUCCESS -> "✅ "; // ✅ success
+            case WARN -> "⚠\uFE0F "; // ⚠️ warn
+            case ERROR -> "❌ "; // ❌ error
+            case CRITICAL -> "\uD83D\uDEA8 "; // 🚨 critical
             default -> "\uD83E\uDD8A "; // 🦊 kuda (custom level)
         };
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.n1netails</groupId>
     <artifactId>n1netails</artifactId>
-    <version>0.3.18</version>
+    <version>0.3.19</version>
     <packaging>pom</packaging>
 
     <url/>


### PR DESCRIPTION
# 🚀 Pull Request

## 📌 Summary
Adding different colors for the discord notifications based on tail level

## 🧪 What Does This Fix or Improve?
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Other (describe below)

## 🔍 Changes
List the notable changes:

- each tail level will produce a different notification color on discord messages

## ✅ Checklist
Please ensure the following:

- [x] Code compiles without errors
- [x] Tests pass successfully
- [x] No breaking changes introduced
- [x] Added or updated documentation if needed
- [x] Branch is up to date with `main`

